### PR TITLE
fix image orientation not being persisted due to NVS key limit of 15 chars

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -52,7 +52,7 @@ typedef enum { ROTATION_MODE_SDCARD = 0, ROTATION_MODE_URL = 1 } rotation_mode_t
 #define NVS_WIFI_PASS_KEY "wifi_pass"
 #define NVS_ROTATE_INTERVAL_KEY "rotate_int"
 #define NVS_AUTO_ROTATE_KEY "auto_rotate"
-#define NVS_IMAGE_ORIENTATION_KEY "image_orientation"
+#define NVS_IMAGE_ORIENTATION_KEY "image_ori"
 #define NVS_BRIGHTNESS_KEY "brightness"
 #define NVS_CONTRAST_KEY "contrast"
 #define NVS_DEEP_SLEEP_KEY "deep_sleep"


### PR DESCRIPTION
The rotation setting wasn't being persisted properly since the ESP32 NVS appears to have a key length limit of 15 chars https://docs.espressif.com/projects/esp-idf/en/v4.3/esp32/api-reference/storage/nvs_flash.html#keys-and-values .