### PR TITLE
Fix GCC 14 build warnings and deprecated HTTP events in latest stable ESP-IDF

### DIFF
--- a/components/epaper_src/GUI_Paint.c
+++ b/components/epaper_src/GUI_Paint.c
@@ -323,7 +323,8 @@ void Paint_DrawPoint(UWORD Xpoint, UWORD Ypoint, UWORD Color, DOT_PIXEL Dot_Pixe
     if (Dot_Style == DOT_FILL_AROUND) {
         for (XDir_Num = 0; XDir_Num < 2 * Dot_Pixel - 1; XDir_Num++) {
             for (YDir_Num = 0; YDir_Num < 2 * Dot_Pixel - 1; YDir_Num++) {
-                if (Xpoint + XDir_Num - Dot_Pixel < 0 || Ypoint + YDir_Num - Dot_Pixel < 0)
+                // Fix: Mathematisch umgestellt, um Unsigned-Underflow zu vermeiden
+                if (Xpoint + XDir_Num < Dot_Pixel || Ypoint + YDir_Num < Dot_Pixel)
                     break;
                 Paint_SetPixel(Xpoint + XDir_Num - Dot_Pixel, Ypoint + YDir_Num - Dot_Pixel, Color);
             }

--- a/components/epaper_src/GUI_Paint.h
+++ b/components/epaper_src/GUI_Paint.h
@@ -72,6 +72,8 @@
 
 #include "../Fonts/fonts.h"
 #include "DEV_Config.h"
+#include <stdbool.h>
+
 
 /**
  * Image attributes

--- a/main/ota_manager.c
+++ b/main/ota_manager.c
@@ -1,5 +1,7 @@
 #include "ota_manager.h"
 
+#include "esp_idf_version.h"
+
 #include <string.h>
 #include <sys/time.h>
 #include <time.h>
@@ -123,12 +125,16 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
     case HTTP_EVENT_REDIRECT:
         ESP_LOGD(TAG, "HTTP_EVENT_REDIRECT");
         break;
+#ifdef HTTP_EVENT_ON_HEADERS_COMPLETE
     case HTTP_EVENT_ON_HEADERS_COMPLETE:
         ESP_LOGD(TAG, "HTTP_EVENT_ON_HEADERS_COMPLETE");
         break;
+#endif
+#ifdef HTTP_EVENT_ON_STATUS_CODE
     case HTTP_EVENT_ON_STATUS_CODE:
         ESP_LOGD(TAG, "HTTP_EVENT_ON_STATUS_CODE");
         break;
+#endif
     }
     return ESP_OK;
 }


### PR DESCRIPTION
Hello again! 

While building the project on the latest ESP-IDF 5.5 (which uses GCC 14), the compiler threw some errors because of strict unsigned checks, a missing include, and deprecated HTTP events that were removed in newer IDF versions.

**Changes in this PR:**
* **`GUI_Paint.h`**: Added `#include <stdbool.h>` to fix the `undeclared identifier 'bool'` error on newer compilers.
* **`GUI_Paint.c`**: Fixed the `comparison of unsigned expression in '< 0' is always false` warning by rearranging the mathematical condition to prevent unsigned underflows.
* **`ota_manager.c`**: Wrapped `HTTP_EVENT_ON_HEADERS_COMPLETE` and `HTTP_EVENT_ON_STATUS_CODE` in `#ifdef` blocks. These events seem to be deprecated/removed in ESP-IDF 5.5+, which causes the build to fail on the latest toolchain.

This ensures the project compiles flawlessly across older and newer IDF versions!