### PR TITLE
feat: Add .epd.gz compression support

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -46,6 +46,7 @@ set(PRIV_REQUIRES
     memfs
     nvs_flash
     sdcard
+    zlib
 )
 
 idf_component_register(

--- a/main/config.h
+++ b/main/config.h
@@ -48,6 +48,7 @@ typedef enum {
 #define CURRENT_JPG_PATH FS_MOUNT_POINT "/.current.jpg"
 #define CURRENT_BMP_PATH FS_MOUNT_POINT "/.current.bmp"
 #define CURRENT_PNG_PATH FS_MOUNT_POINT "/.current.png"
+#define CURRENT_EPD_PATH FS_MOUNT_POINT "/.current_epd.gz"
 #define CURRENT_IMAGE_LINK FS_MOUNT_POINT "/.current.lnk"
 #define CURRENT_CALIBRATION_PATH FS_MOUNT_POINT "/.calibration.png"
 

--- a/main/display_manager.c
+++ b/main/display_manager.c
@@ -4,7 +4,9 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/stat.h>
+#include <sys/stat.h>
 #include <unistd.h>
+#include <zlib.h>
 
 #include "GUI_BMPfile.h"
 #include "GUI_PNGfile.h"
@@ -33,6 +35,9 @@ static char last_displayed_image[256] = {0};  // Internal state: last displayed 
 
 static uint8_t *epd_image_buffer = NULL;
 static uint32_t image_buffer_size;
+
+// Forward Declaration
+static esp_err_t display_manager_show_raw_gzip(const char *filename);
 
 // Load last displayed image from NVS
 static void load_last_displayed_image(void)
@@ -137,8 +142,17 @@ esp_err_t display_manager_show_image(const char *filename)
     // Detect file type by extension
     const char *ext = strrchr(filename, '.');
     bool is_png = (ext != NULL && strcasecmp(ext, ".png") == 0);
+    // ".epd.gz" will have ext pointing to ".gz", so we must check for either ".gz" or ".epd"
+    bool is_epd_gz = (ext != NULL && (strcasecmp(ext, ".gz") == 0 || strcasecmp(ext, ".epd") == 0));
 
-    if (is_png) {
+    if (is_epd_gz) {
+        ESP_LOGI(TAG, "Reading EPD.GZ file into buffer");
+        if (display_manager_show_raw_gzip(filename) != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to read EPD.GZ file");
+            xSemaphoreGive(display_mutex);
+            return ESP_FAIL;
+        }
+    } else if (is_png) {
         ESP_LOGI(TAG, "Reading PNG file into buffer");
         if (GUI_ReadPng_RGB_6Color(filename, 0, 0) != 0) {
             ESP_LOGE(TAG, "Failed to read PNG file");
@@ -218,6 +232,79 @@ esp_err_t display_manager_show_rgb_buffer(const uint8_t *rgb_buffer, int width, 
     xSemaphoreGive(display_mutex);
 
     ESP_LOGI(TAG, "RGB buffer displayed successfully");
+    return ESP_OK;
+}
+
+static esp_err_t display_manager_show_raw_gzip(const char *filename)
+{
+    FILE *fp = fopen(filename, "rb");
+    if (!fp) {
+        ESP_LOGE(TAG, "Failed to open raw gzip file: %s", filename);
+        return ESP_FAIL;
+    }
+
+    fseek(fp, 0, SEEK_END);
+    long compressed_size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+
+    uint8_t *compressed_data = heap_caps_malloc(compressed_size, MALLOC_CAP_SPIRAM);
+    if (!compressed_data) {
+        fclose(fp);
+        return ESP_ERR_NO_MEM;
+    }
+    fread(compressed_data, 1, compressed_size, fp);
+    fclose(fp);
+
+    int width = Paint.Width;
+    int height = Paint.Height;
+    int uncompressed_size = (width * height + 1) / 2;
+
+    uint8_t *uncompressed_data = heap_caps_malloc(uncompressed_size, MALLOC_CAP_SPIRAM);
+    if (!uncompressed_data) {
+        heap_caps_free(compressed_data);
+        return ESP_ERR_NO_MEM;
+    }
+
+    z_stream strm = {0};
+    strm.avail_in = compressed_size;
+    strm.next_in = compressed_data;
+    strm.avail_out = uncompressed_size;
+    strm.next_out = uncompressed_data;
+
+    // 16 + MAX_WBITS enables gzip decoding
+    if (inflateInit2(&strm, 16 + MAX_WBITS) != Z_OK) {
+        ESP_LOGE(TAG, "inflateInit2 failed");
+        heap_caps_free(compressed_data);
+        heap_caps_free(uncompressed_data);
+        return ESP_FAIL;
+    }
+
+    int ret = inflate(&strm, Z_FINISH);
+    inflateEnd(&strm);
+    heap_caps_free(compressed_data);
+
+    if (ret != Z_STREAM_END && ret != Z_OK) {
+        ESP_LOGE(TAG, "Decompression failed: %d", ret);
+        heap_caps_free(uncompressed_data);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Decompressed raw image successfully, rendering via Paint_SetPixel");
+
+    int byteIdx = 0;
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x += 2) {
+            uint8_t byte = uncompressed_data[byteIdx++];
+            uint8_t p1 = (byte >> 4) & 0x0F;
+            uint8_t p2 = byte & 0x0F;
+            Paint_SetPixel(x, y, p1);
+            if (x + 1 < width) {
+                Paint_SetPixel(x + 1, y, p2);
+            }
+        }
+    }
+
+    heap_caps_free(uncompressed_data);
     return ESP_OK;
 }
 
@@ -420,8 +507,8 @@ static void rotate_sequential(char **enabled_albums, int album_count)
                 }
 
                 const char *ext = strrchr(entry->d_name, '.');
-                if (ext && (strcmp(ext, ".bmp") == 0 || strcmp(ext, ".BMP") == 0 ||
-                            strcmp(ext, ".png") == 0 || strcmp(ext, ".PNG") == 0)) {
+                if (ext && (strcasecmp(ext, ".bmp") == 0 || strcasecmp(ext, ".png") == 0 ||
+                            strcasecmp(ext, ".gz") == 0 || strcasecmp(ext, ".epd") == 0)) {
                     char fullpath[512];
                     snprintf(fullpath, sizeof(fullpath), "%s/%s", album_path, entry->d_name);
                     ESP_LOGD(TAG, "  Found image [%ld]: %s", (long) current_idx, fullpath);
@@ -489,8 +576,8 @@ static void rotate_random(char **enabled_albums, int album_count)
                     continue;
                 }
                 const char *ext = strrchr(entry->d_name, '.');
-                if (ext && (strcmp(ext, ".bmp") == 0 || strcmp(ext, ".BMP") == 0 ||
-                            strcmp(ext, ".png") == 0 || strcmp(ext, ".PNG") == 0)) {
+                if (ext && (strcasecmp(ext, ".bmp") == 0 || strcasecmp(ext, ".png") == 0 ||
+                            strcasecmp(ext, ".gz") == 0 || strcasecmp(ext, ".epd") == 0)) {
                     total_image_count++;
                 }
             }
@@ -528,8 +615,8 @@ static void rotate_random(char **enabled_albums, int album_count)
                 }
 
                 const char *ext = strrchr(entry->d_name, '.');
-                if (ext && (strcmp(ext, ".bmp") == 0 || strcmp(ext, ".BMP") == 0 ||
-                            strcmp(ext, ".png") == 0 || strcmp(ext, ".PNG") == 0)) {
+                if (ext && (strcasecmp(ext, ".bmp") == 0 || strcasecmp(ext, ".png") == 0 ||
+                            strcasecmp(ext, ".gz") == 0 || strcasecmp(ext, ".epd") == 0)) {
                     char *fullpath = malloc(512);
                     if (!fullpath) {
                         ESP_LOGE(TAG, "Failed to allocate path buffer");

--- a/main/display_manager.c
+++ b/main/display_manager.c
@@ -4,7 +4,6 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/stat.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #include <zlib.h>
 

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -267,12 +267,12 @@ static esp_err_t parse_multipart_upload(httpd_req_t *req, const char *base_dir,
                         if (require_png) {
                             // Check PNG extension for image field
                             char *ext = strrchr(result->original_filename, '.');
-                            if (!ext || strcasecmp(ext, ".png") != 0) {
+                            if (!ext || (strcasecmp(ext, ".png") != 0 && strcasecmp(ext, ".gz") != 0 && strcasecmp(ext, ".epd") != 0)) {
                                 if (fp)
                                     fclose(fp);
                                 free(buf);
                                 httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
-                                                    "Only PNG files are allowed");
+                                                    "Only PNG and EPD.GZ files are allowed");
                                 return ESP_FAIL;
                             }
                         }
@@ -434,7 +434,19 @@ static esp_err_t display_image_direct_handler(httpd_req_t *req)
         }
 
         // Process the uploaded image
-        if (image_format == IMAGE_FORMAT_PNG) {
+        if (image_format == IMAGE_FORMAT_EPD_GZ) {
+            unlink(CURRENT_EPD_PATH);
+            if (rename(result.image_path, CURRENT_EPD_PATH) != 0) {
+                ESP_LOGE(TAG, "Failed to move EPD.GZ");
+                unlink(result.image_path);
+                if (result.has_thumbnail)
+                    unlink(result.thumbnail_path);
+                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
+                                    "Failed to process EPD.GZ");
+                return ESP_FAIL;
+            }
+            display_path = CURRENT_EPD_PATH;
+        } else if (image_format == IMAGE_FORMAT_PNG) {
             unlink(temp_png_path);
 
             bool already_processed = image_processor_is_processed(result.image_path);
@@ -630,6 +642,8 @@ static esp_err_t display_image_direct_handler(httpd_req_t *req)
             ESP_LOGI(TAG, "Detected BMP format from file");
         } else if (image_format == IMAGE_FORMAT_JPG) {
             ESP_LOGI(TAG, "Detected JPG format from file");
+        } else if (image_format == IMAGE_FORMAT_EPD_GZ) {
+            ESP_LOGI(TAG, "Detected EPD.GZ format from file");
         } else {
             ESP_LOGE(TAG, "Unsupported image format or format detection failed");
             unlink(temp_upload_path);
@@ -647,7 +661,15 @@ static esp_err_t display_image_direct_handler(httpd_req_t *req)
     esp_err_t err = ESP_OK;
     const char *display_path = NULL;
 
-    if (image_format == IMAGE_FORMAT_BMP) {
+    if (image_format == IMAGE_FORMAT_EPD_GZ) {
+        if (rename(temp_upload_path, CURRENT_EPD_PATH) != 0) {
+            ESP_LOGE(TAG, "Failed to move uploaded EPD.GZ to temp location");
+            unlink(temp_upload_path);
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to process EPD.GZ");
+            return ESP_FAIL;
+        }
+        display_path = CURRENT_EPD_PATH;
+    } else if (image_format == IMAGE_FORMAT_BMP) {
         // Move uploaded BMP to temp location
         if (rename(temp_upload_path, temp_bmp_path) != 0) {
             ESP_LOGE(TAG, "Failed to move uploaded BMP to temp location");
@@ -811,6 +833,8 @@ static esp_err_t display_image_direct_handler(httpd_req_t *req)
                 httpd_resp_sendstr(req, json_str);
                 free(json_str);
                 cJSON_Delete(response);
+
+                return ESP_OK;
             }
         }
         display_path = temp_png_path;
@@ -946,25 +970,30 @@ static esp_err_t upload_image_handler(httpd_req_t *req)
         filename_base[sizeof(filename_base) - 1] = '\0';
     }
 
-    char png_filename[128];
-    char jpg_filename[128];
-    char final_png_path[512];
+    char file_ext[16] = ".png";
+    if (ext && (strcasecmp(ext, ".gz") == 0 || strcasecmp(ext, ".epd") == 0)) {
+        strcpy(file_ext, ".epd.gz");
+    }
+
+    char dest_filename[256];
+    char jpg_filename[256];
+    char final_dest_path[512];
     char final_thumb_path[512];
 
     // Use original filename (will overwrite if exists)
-    snprintf(png_filename, sizeof(png_filename), "%s.png", filename_base);
+    snprintf(dest_filename, sizeof(dest_filename), "%s%s", filename_base, file_ext);
     snprintf(jpg_filename, sizeof(jpg_filename), "%s.jpg", filename_base);
-    snprintf(final_png_path, sizeof(final_png_path), "%s/%s", album_path, png_filename);
+    snprintf(final_dest_path, sizeof(final_dest_path), "%s/%s", album_path, dest_filename);
     snprintf(final_thumb_path, sizeof(final_thumb_path), "%s/%s", album_path, jpg_filename);
 
     // Remove old files
-    unlink(final_png_path);
+    unlink(final_dest_path);
     unlink(final_thumb_path);
 
-    // Move PNG to final location
-    ESP_LOGI(TAG, "Saving PNG: %s -> %s", result.image_path, final_png_path);
-    if (rename(result.image_path, final_png_path) != 0) {
-        ESP_LOGE(TAG, "Failed to move PNG to album");
+    // Move PNG/EPD.GZ to final location
+    ESP_LOGI(TAG, "Saving image: %s -> %s", result.image_path, final_dest_path);
+    if (rename(result.image_path, final_dest_path) != 0) {
+        ESP_LOGE(TAG, "Failed to move image to album");
         unlink(result.image_path);
         unlink(result.thumbnail_path);
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to save image");
@@ -977,11 +1006,11 @@ static esp_err_t upload_image_handler(httpd_req_t *req)
         unlink(result.thumbnail_path);
     }
 
-    ESP_LOGI(TAG, "Image saved successfully: %s (thumbnail: %s)", png_filename, jpg_filename);
+    ESP_LOGI(TAG, "Image saved successfully: %s (thumbnail: %s)", dest_filename, jpg_filename);
 
     cJSON *response = cJSON_CreateObject();
     cJSON_AddStringToObject(response, "status", "success");
-    cJSON_AddStringToObject(response, "filepath", final_png_path);
+    cJSON_AddStringToObject(response, "filepath", final_dest_path);
 
     char *json_str = cJSON_Print(response);
     httpd_resp_set_type(req, "application/json");
@@ -1157,9 +1186,15 @@ static esp_err_t delete_image_handler(httpd_req_t *req)
     char jpg_filename[256];
     strncpy(jpg_filename, filepath_copy, sizeof(jpg_filename) - 1);
     jpg_filename[sizeof(jpg_filename) - 1] = '\0';
-    char *ext = strrchr(jpg_filename, '.');
-    if (ext && (strcasecmp(ext, ".bmp") == 0 || strcasecmp(ext, ".png") == 0)) {
-        strcpy(ext, ".jpg");
+    char *epd_ext = strstr(jpg_filename, ".epd.gz");
+    if (epd_ext) {
+        strcpy(epd_ext, ".jpg");
+    } else {
+        char *ext = strrchr(jpg_filename, '.');
+        if (ext && (strcasecmp(ext, ".bmp") == 0 || strcasecmp(ext, ".png") == 0 ||
+                    strcasecmp(ext, ".epd") == 0 || strcasecmp(ext, ".gz") == 0)) {
+            strcpy(ext, ".jpg");
+        }
     }
 
     char jpg_path[512];
@@ -2139,8 +2174,8 @@ static esp_err_t album_images_handler(httpd_req_t *req)
                 continue;
             }
             const char *ext = strrchr(entry->d_name, '.');
-            if (ext && (strcmp(ext, ".bmp") == 0 || strcmp(ext, ".BMP") == 0 ||
-                        strcmp(ext, ".png") == 0 || strcmp(ext, ".PNG") == 0)) {
+            if (ext && (strcasecmp(ext, ".bmp") == 0 || strcasecmp(ext, ".png") == 0 ||
+                        strcasecmp(ext, ".epd") == 0 || strcasecmp(ext, ".gz") == 0)) {
                 cJSON *image_obj = cJSON_CreateObject();
                 cJSON_AddStringToObject(image_obj, "filename", entry->d_name);
                 cJSON_AddStringToObject(image_obj, "album", decoded_album_name);
@@ -2150,7 +2185,13 @@ static esp_err_t album_images_handler(httpd_req_t *req)
                 char thumbnail_path[512];
 
                 // Extract base name without extension
-                int base_len = ext - entry->d_name;
+                const char *epd_ext = strstr(entry->d_name, ".epd.gz");
+                int base_len;
+                if (epd_ext) {
+                    base_len = epd_ext - entry->d_name;
+                } else {
+                    base_len = ext - entry->d_name;
+                }
                 snprintf(thumbnail_name, sizeof(thumbnail_name), "%.*s.jpg", base_len,
                          entry->d_name);
                 snprintf(thumbnail_path, sizeof(thumbnail_path), "%s/%s", album_path,

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -267,7 +267,9 @@ static esp_err_t parse_multipart_upload(httpd_req_t *req, const char *base_dir,
                         if (require_png) {
                             // Check PNG extension for image field
                             char *ext = strrchr(result->original_filename, '.');
-                            if (!ext || (strcasecmp(ext, ".png") != 0 && strcasecmp(ext, ".gz") != 0 && strcasecmp(ext, ".epd") != 0)) {
+                            if (!ext ||
+                                (strcasecmp(ext, ".png") != 0 && strcasecmp(ext, ".gz") != 0 &&
+                                 strcasecmp(ext, ".epd") != 0)) {
                                 if (fp)
                                     fclose(fp);
                                 free(buf);

--- a/main/image_processor.c
+++ b/main/image_processor.c
@@ -699,6 +699,8 @@ image_format_t image_processor_detect_format_buffer(const uint8_t *data, size_t 
         return IMAGE_FORMAT_BMP;
     } else if (data[0] == 0xFF && data[1] == 0xD8) {
         return IMAGE_FORMAT_JPG;
+    } else if (data[0] == 0x1F && data[1] == 0x8B) {
+        return IMAGE_FORMAT_EPD_GZ;
     }
 
     return IMAGE_FORMAT_UNKNOWN;
@@ -1046,6 +1048,8 @@ image_format_t image_processor_detect_format(const char *input_path)
         return IMAGE_FORMAT_BMP;
     } else if (magic[0] == 0xFF && magic[1] == 0xD8) {
         return IMAGE_FORMAT_JPG;
+    } else if (magic[0] == 0x1F && magic[1] == 0x8B) {
+        return IMAGE_FORMAT_EPD_GZ;
     }
 
     return IMAGE_FORMAT_UNKNOWN;

--- a/main/image_processor.h
+++ b/main/image_processor.h
@@ -18,7 +18,8 @@ typedef enum {
     IMAGE_FORMAT_UNKNOWN,
     IMAGE_FORMAT_PNG,
     IMAGE_FORMAT_BMP,
-    IMAGE_FORMAT_JPG
+    IMAGE_FORMAT_JPG,
+    IMAGE_FORMAT_EPD_GZ
 } image_format_t;
 
 /**

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1557,6 +1557,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1923,6 +1924,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3076,6 +3078,7 @@
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -3327,6 +3330,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3402,6 +3406,7 @@
       "integrity": "sha512-Q4SC/4TqbNvaZIFb9YsfBqkGlYHbJJJ6uU3CnRBZqLUF3s5eCMVZAaV4GkTbehIH/bhSj42lMXztOwc71u6rVw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vuetify/loader-shared": "^2.1.2",
         "debug": "^4.3.3",
@@ -3421,6 +3426,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",
@@ -3508,6 +3514,7 @@
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.11.7.tgz",
       "integrity": "sha512-3nK1mKTXQRbU4QXukV4WIbs5YZgMK19flHpFq3pU+6Fpa5YLB8RyyK1BLWAW8JmhSVcaqVUcB/EJ3oJ8g3XNCw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"

--- a/webapp/src/components/ImageUpload.vue
+++ b/webapp/src/components/ImageUpload.vue
@@ -178,38 +178,47 @@ async function uploadImage(mode = "upload") {
     const outH = result.canvas.height;
     const imgData = ctx_result.getImageData(0, 0, outW, outH);
     const data = imgData.data;
-    
+
     // We pack 2 pixels into one byte (4 bits per pixel)
     const rawBuffer = new Uint8Array(Math.ceil((outW * outH) / 2));
-    
+
     let byteIdx = 0;
     for (let i = 0; i < data.length; i += 8) {
       // Pixel 1
-      const r1 = data[i], g1 = data[i+1], b1 = data[i+2];
+      const r1 = data[i],
+        g1 = data[i + 1],
+        b1 = data[i + 2];
       let p1 = 1; // Default white
-      if (r1===0 && g1===0 && b1===0) p1 = 0;           // Black
-      else if (r1===255 && g1===255 && b1===255) p1 = 1;// White
-      else if (r1===255 && g1===255 && b1===0) p1 = 2;  // Yellow
-      else if (r1===255 && g1===0 && b1===0) p1 = 3;    // Red
-      else if (r1===0 && g1===0 && b1===255) p1 = 5;    // Blue
-      else if (r1===0 && g1===255 && b1===0) p1 = 6;    // Green
+      if (r1 === 0 && g1 === 0 && b1 === 0)
+        p1 = 0; // Black
+      else if (r1 === 255 && g1 === 255 && b1 === 255)
+        p1 = 1; // White
+      else if (r1 === 255 && g1 === 255 && b1 === 0)
+        p1 = 2; // Yellow
+      else if (r1 === 255 && g1 === 0 && b1 === 0)
+        p1 = 3; // Red
+      else if (r1 === 0 && g1 === 0 && b1 === 255)
+        p1 = 5; // Blue
+      else if (r1 === 0 && g1 === 255 && b1 === 0) p1 = 6; // Green
 
       // Pixel 2 (Handle odd widths by padding with white if out of bounds)
       let p2 = 1;
       if (i + 4 < data.length) {
-        const r2 = data[i+4], g2 = data[i+5], b2 = data[i+6];
-        if (r2===0 && g2===0 && b2===0) p2 = 0;
-        else if (r2===255 && g2===255 && b2===255) p2 = 1;
-        else if (r2===255 && g2===255 && b2===0) p2 = 2;
-        else if (r2===255 && g2===0 && b2===0) p2 = 3;
-        else if (r2===0 && g2===0 && b2===255) p2 = 5;
-        else if (r2===0 && g2===255 && b2===0) p2 = 6;
+        const r2 = data[i + 4],
+          g2 = data[i + 5],
+          b2 = data[i + 6];
+        if (r2 === 0 && g2 === 0 && b2 === 0) p2 = 0;
+        else if (r2 === 255 && g2 === 255 && b2 === 255) p2 = 1;
+        else if (r2 === 255 && g2 === 255 && b2 === 0) p2 = 2;
+        else if (r2 === 255 && g2 === 0 && b2 === 0) p2 = 3;
+        else if (r2 === 0 && g2 === 0 && b2 === 255) p2 = 5;
+        else if (r2 === 0 && g2 === 255 && b2 === 0) p2 = 6;
       }
-      
+
       // Pack into byte (p1 in high nibble, p2 in low nibble)
-      rawBuffer[byteIdx++] = (p1 << 4) | (p2 & 0x0F);
+      rawBuffer[byteIdx++] = (p1 << 4) | (p2 & 0x0f);
     }
-    
+
     // Compress with GZIP
     const compressedBuffer = pako.gzip(rawBuffer);
     const rawBlob = new Blob([compressedBuffer], { type: "application/gzip" });

--- a/webapp/src/components/ImageUpload.vue
+++ b/webapp/src/components/ImageUpload.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed, watch } from "vue";
 import { useAppStore, useSettingsStore } from "../stores";
 import ImageProcessing from "./ImageProcessing.vue";
+import pako from "pako";
 
 const appStore = useAppStore();
 const settingsStore = useSettingsStore();
@@ -170,14 +171,52 @@ async function uploadImage(mode = "upload") {
       ctx.putImageData(imageData, 0, 0);
     }
 
-    // Convert processed canvas to PNG blob
-    const pngBlob = await new Promise((resolve) => {
-      result.canvas.toBlob(resolve, "image/png");
-    });
+    // Instead of encoding to PNG, we map the RGB pixels to exactly 4-bit indices
+    // matching the E-Ink hardware (0=Black, 1=White, 2=Yellow, 3=Red, 5=Blue, 6=Green)
+    const ctx_result = result.canvas.getContext("2d");
+    const outW = result.canvas.width;
+    const outH = result.canvas.height;
+    const imgData = ctx_result.getImageData(0, 0, outW, outH);
+    const data = imgData.data;
+    
+    // We pack 2 pixels into one byte (4 bits per pixel)
+    const rawBuffer = new Uint8Array(Math.ceil((outW * outH) / 2));
+    
+    let byteIdx = 0;
+    for (let i = 0; i < data.length; i += 8) {
+      // Pixel 1
+      const r1 = data[i], g1 = data[i+1], b1 = data[i+2];
+      let p1 = 1; // Default white
+      if (r1===0 && g1===0 && b1===0) p1 = 0;           // Black
+      else if (r1===255 && g1===255 && b1===255) p1 = 1;// White
+      else if (r1===255 && g1===255 && b1===0) p1 = 2;  // Yellow
+      else if (r1===255 && g1===0 && b1===0) p1 = 3;    // Red
+      else if (r1===0 && g1===0 && b1===255) p1 = 5;    // Blue
+      else if (r1===0 && g1===255 && b1===0) p1 = 6;    // Green
 
-    // Generate filename with .png extension
+      // Pixel 2 (Handle odd widths by padding with white if out of bounds)
+      let p2 = 1;
+      if (i + 4 < data.length) {
+        const r2 = data[i+4], g2 = data[i+5], b2 = data[i+6];
+        if (r2===0 && g2===0 && b2===0) p2 = 0;
+        else if (r2===255 && g2===255 && b2===255) p2 = 1;
+        else if (r2===255 && g2===255 && b2===0) p2 = 2;
+        else if (r2===255 && g2===0 && b2===0) p2 = 3;
+        else if (r2===0 && g2===0 && b2===255) p2 = 5;
+        else if (r2===0 && g2===255 && b2===0) p2 = 6;
+      }
+      
+      // Pack into byte (p1 in high nibble, p2 in low nibble)
+      rawBuffer[byteIdx++] = (p1 << 4) | (p2 & 0x0F);
+    }
+    
+    // Compress with GZIP
+    const compressedBuffer = pako.gzip(rawBuffer);
+    const rawBlob = new Blob([compressedBuffer], { type: "application/gzip" });
+
+    // Generate filename with .epd.gz extension
     const originalName = selectedFile.value.name.replace(/\.[^/.]+$/, "");
-    const pngFilename = `${originalName}.png`;
+    const rawFilename = `${originalName}.epd.gz`;
 
     // Generate thumbnail from original canvas (before rotation)
     const thumbCanvas = imageProcessor.generateThumbnail(
@@ -192,7 +231,7 @@ async function uploadImage(mode = "upload") {
 
     // Create form data
     const formData = new FormData();
-    formData.append("image", pngBlob, pngFilename);
+    formData.append("image", rawBlob, rawFilename);
     formData.append("thumbnail", thumbnailBlob, thumbFilename);
 
     // Determine upload URL based on mode and capability


### PR DESCRIPTION
### Why `.epd.gz` compression?
The goal is to shift the heavy lifting of image decoding (JPEG/PNG), resizing, and color-dithering from the ESP32 to the client's browser. The ESP32 only has to uncompress and display the pre-processed data, which:
1. **Saves RAM and CPU** on the ESP32 (no need to hold large decoded RGB images in memory).
2. **Speeds up** the image display process significantly.
3. **Saves storage space** (on internal flash or SD card) because the 4-bit indexed EPD data is highly compressible using standard [gzip](cci:1://file:///c:/VS%20Code/esp32-photoframe-github/main/display_manager.c:237:0-308:1).

### How it works (Tools & Workflow)
1. **Frontend (Webapp):** 
   - When an image is uploaded, the Vue.js app uses the `@aitjcize/epaper-image-convert` library to resize and dither the image for the 6-color Spectra 6 display.
   - The RGB output is perfectly mapped to the hardware's 4-bit color indices (0=Black, 1=White, 2=Yellow, etc.). We then pack two pixels into a single byte.
   - The resulting raw 4-bit buffer is compressed using `pako` (a JavaScript zlib port) and uploaded with the `.epd.gz` extension.
   
2. **Backend (ESP32 Firmware):**
   - The `http_server.c` accepts the `.epd.gz` file and saves it directly to storage.
   - When displaying, [display_manager_show_raw_gzip()](cci:1://file:///c:/VS%20Code/esp32-photoframe-github/main/display_manager.c:237:0-308:1) allocates a buffer in SPIRAM and uses the standard ESP-IDF `zlib` library (`inflate()`) to decompress the 4-bit data entirely in memory.
   - It iterates through the uncompressed bytes, unpacks the 2 pixels per byte, and writes them directly to the E-Paper buffer via `Paint_SetPixel()`.
   - This cleanly bypasses the heavy decoding and processing pipeline in `image_processor.c`.
