### PR TITLE
feat: add reTerminal E1004 board support

### DIFF
--- a/components/board_hal/CMakeLists.txt
+++ b/components/board_hal/CMakeLists.txt
@@ -6,6 +6,7 @@ set(PRIV_REQS
     esp_driver_i2c
     esp_driver_spi
     pmic_driver_axp2101
+    pmic_driver_sy6974b
     rtc_driver_pcf85063
     rtc_driver_pcf8563
     sdcard
@@ -21,6 +22,8 @@ elseif(CONFIG_BOARD_DRIVER_SEEEDSTUDIO_XIAO_EE04)
     list(APPEND SRCS "src/driver_seeedstudio_xiao_ee04.c")
 elseif(CONFIG_BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1002)
     list(APPEND SRCS "src/driver_seeedstudio_reterminal_e1002.c")
+elseif(CONFIG_BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1004)
+    list(APPEND SRCS "src/driver_seeedstudio_reterminal_e1004.c")
 endif()
 
 idf_component_register(

--- a/components/board_hal/Kconfig
+++ b/components/board_hal/Kconfig
@@ -53,6 +53,7 @@ menu "Board Configuration"
 
         config BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1004
             bool "Seeed reTerminal E1004 (13.3in Spectra 6)"
+            select PMIC_DRIVER_SY6974B
             select SDCARD_DRIVER_SPI
             select SENSOR_DRIVER_SHT40
             select RTC_DRIVER_PCF8563

--- a/components/board_hal/Kconfig
+++ b/components/board_hal/Kconfig
@@ -51,11 +51,25 @@ menu "Board Configuration"
                 Includes battery monitoring and deep sleep support.
                 SD card: SPI interface.
 
+        config BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1004
+            bool "Seeed reTerminal E1004 (13.3in Spectra 6)"
+            select SDCARD_DRIVER_SPI
+            select SENSOR_DRIVER_SHT40
+            select RTC_DRIVER_PCF8563
+            select EP_DRIVER_ED2208_GCA
+            help
+                Driver for Seeed reTerminal E1004 with 13.3" Spectra 6 display (ED2208).
+                Features ESP32-S3R8 (8MB Octal PSRAM), SY6974B I2C charger, PCF8563M RTC,
+                SHT40 temperature/humidity sensor, SD card with TPS22916 power gating,
+                buzzer, status LED, 3 physical buttons, 3 I2C touch buttons, and
+                dual I2C buses. Battery ADC via GPIO1 with TPS22916 load switch.
+                SD card: SPI interface.
+
     endchoice
 
     config USE_INTERNAL_FLASH_STORAGE
         bool "Use internal flash as storage (LittleFS)"
-        default y if BOARD_DRIVER_SEEEDSTUDIO_XIAO_EE02 || BOARD_DRIVER_SEEEDSTUDIO_XIAO_EE04 || BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1002
+        default y if BOARD_DRIVER_SEEEDSTUDIO_XIAO_EE02 || BOARD_DRIVER_SEEEDSTUDIO_XIAO_EE04 || BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1002 || BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1004
         default n
         help
             Mounts a LittleFS partition from internal flash to use as storage.

--- a/components/board_hal/include/board_hal.h
+++ b/components/board_hal/include/board_hal.h
@@ -21,6 +21,7 @@ typedef enum {
     BOARD_TYPE_SEEEDSTUDIO_XIAO_EE02,
     BOARD_TYPE_SEEEDSTUDIO_XIAO_EE04,
     BOARD_TYPE_SEEEDSTUDIO_RETERMINAL_E1002,
+    BOARD_TYPE_SEEEDSTUDIO_RETERMINAL_E1004,
     BOARD_TYPE_UNKNOWN
 } board_type_t;
 
@@ -32,6 +33,8 @@ typedef enum {
 #include "board_seeedstudio_xiao_ee04.h"
 #elif defined(CONFIG_BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1002)
 #include "board_seeedstudio_reterminal_e1002.h"
+#elif defined(CONFIG_BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1004)
+#include "board_seeedstudio_reterminal_e1004.h"
 #else
 // Default definitions if no board selected (fallback)
 #error "No board selected! Please define CONFIG_BOARD_DRIVER_..."

--- a/components/board_hal/include/board_seeedstudio_reterminal_e1004.h
+++ b/components/board_hal/include/board_seeedstudio_reterminal_e1004.h
@@ -1,0 +1,58 @@
+#ifndef BOARD_SEEEDSTUDIO_RETERMINAL_E1004_H
+#define BOARD_SEEEDSTUDIO_RETERMINAL_E1004_H
+
+#include "driver/gpio.h"
+
+// Board Info
+#define BOARD_HAL_NAME "seeedstudio_reterminal_e1004"
+#define BOARD_HAL_TYPE BOARD_TYPE_SEEEDSTUDIO_RETERMINAL_E1004
+
+// Button Definitions (physical keys)
+#define BOARD_HAL_WAKEUP_KEY GPIO_NUM_5  // KEY2 (refresh)
+#define BOARD_HAL_ROTATE_KEY GPIO_NUM_3  // KEY0 (page up)
+#define BOARD_HAL_CLEAR_KEY GPIO_NUM_4   // KEY1 (page down)
+
+// SPI Pins
+#define BOARD_HAL_SPI_SCLK_PIN GPIO_NUM_7
+#define BOARD_HAL_SPI_MOSI_PIN GPIO_NUM_9
+#define BOARD_HAL_SPI_MISO_PIN GPIO_NUM_8
+
+// E-Paper Display Pins (ED2208 13.3" Spectra 6, 60-pin FPC)
+#define BOARD_HAL_EPD_CS_PIN    GPIO_NUM_10  // SCREEN_CS#
+#define BOARD_HAL_EPD_DC_PIN    GPIO_NUM_11  // SCREEN_DC#
+#define BOARD_HAL_EPD_ENABLE_PIN GPIO_NUM_12 // SCREEN_EN#
+#define BOARD_HAL_EPD_BUSY_PIN  GPIO_NUM_13  // SCREEN_BUSY#
+#define BOARD_HAL_EPD_RST_PIN   GPIO_NUM_38  // SCREEN_RST#
+
+// SD Card Pins
+#define BOARD_HAL_SD_CS_PIN     GPIO_NUM_14  // SD_CS
+#define BOARD_HAL_SD_DET_PIN    GPIO_NUM_15  // SD_DET (card detect, active-low)
+#define BOARD_HAL_SD_PWR_PIN    GPIO_NUM_16  // SD_EN (TPS22916 load switch)
+
+// I2C Bus 0 — SY6974B charger, PCF8563M RTC, SHT40 sensor
+#define BOARD_HAL_I2C_SDA_PIN   GPIO_NUM_19
+#define BOARD_HAL_I2C_SCL_PIN   GPIO_NUM_20
+
+// I2C Bus 1 — Touch buttons
+#define BOARD_HAL_I2C1_SDA_PIN  GPIO_NUM_39
+#define BOARD_HAL_I2C1_SCL_PIN  GPIO_NUM_40
+
+// Battery ADC
+#define BOARD_HAL_BAT_ADC_PIN   ADC_CHANNEL_0  // GPIO1
+#define BOARD_HAL_BAT_EN_PIN    GPIO_NUM_21     // VBAT_EN (TPS22916 ADC enable)
+
+// Power Management
+#define BOARD_HAL_POWER_EN_PIN  GPIO_NUM_46     // System power enable
+#define BOARD_HAL_SY_INT_PIN    GPIO_NUM_47     // SY6974B charger interrupt
+
+// Buzzer
+#define BOARD_HAL_BUZZER_PIN    GPIO_NUM_45
+
+// Onboard Status LED (active-high)
+#define BOARD_HAL_LED_PIN       GPIO_NUM_48
+#define BOARD_HAL_LED_INVERTED  false
+
+// Display Configuration
+#define BOARD_HAL_DISPLAY_ROTATION_DEG 0
+
+#endif  // BOARD_SEEEDSTUDIO_RETERMINAL_E1004_H

--- a/components/board_hal/include/board_seeedstudio_reterminal_e1004.h
+++ b/components/board_hal/include/board_seeedstudio_reterminal_e1004.h
@@ -18,39 +18,39 @@
 #define BOARD_HAL_SPI_MISO_PIN GPIO_NUM_8
 
 // E-Paper Display Pins (ED2208 13.3" Spectra 6, 60-pin FPC)
-#define BOARD_HAL_EPD_CS_PIN    GPIO_NUM_10  // SCREEN_CS#
-#define BOARD_HAL_EPD_DC_PIN    GPIO_NUM_11  // SCREEN_DC#
-#define BOARD_HAL_EPD_ENABLE_PIN GPIO_NUM_12 // SCREEN_EN#
-#define BOARD_HAL_EPD_BUSY_PIN  GPIO_NUM_13  // SCREEN_BUSY#
-#define BOARD_HAL_EPD_RST_PIN   GPIO_NUM_38  // SCREEN_RST#
+#define BOARD_HAL_EPD_CS_PIN GPIO_NUM_10      // SCREEN_CS#
+#define BOARD_HAL_EPD_DC_PIN GPIO_NUM_11      // SCREEN_DC#
+#define BOARD_HAL_EPD_ENABLE_PIN GPIO_NUM_12  // SCREEN_EN#
+#define BOARD_HAL_EPD_BUSY_PIN GPIO_NUM_13    // SCREEN_BUSY#
+#define BOARD_HAL_EPD_RST_PIN GPIO_NUM_38     // SCREEN_RST#
 
 // SD Card Pins
-#define BOARD_HAL_SD_CS_PIN     GPIO_NUM_14  // SD_CS
-#define BOARD_HAL_SD_DET_PIN    GPIO_NUM_15  // SD_DET (card detect, active-low)
-#define BOARD_HAL_SD_PWR_PIN    GPIO_NUM_16  // SD_EN (TPS22916 load switch)
+#define BOARD_HAL_SD_CS_PIN GPIO_NUM_14   // SD_CS
+#define BOARD_HAL_SD_DET_PIN GPIO_NUM_15  // SD_DET (card detect, active-low)
+#define BOARD_HAL_SD_PWR_PIN GPIO_NUM_16  // SD_EN (TPS22916 load switch)
 
 // I2C Bus 0 — SY6974B charger, PCF8563M RTC, SHT40 sensor
-#define BOARD_HAL_I2C_SDA_PIN   GPIO_NUM_19
-#define BOARD_HAL_I2C_SCL_PIN   GPIO_NUM_20
+#define BOARD_HAL_I2C_SDA_PIN GPIO_NUM_19
+#define BOARD_HAL_I2C_SCL_PIN GPIO_NUM_20
 
 // I2C Bus 1 — Touch buttons
-#define BOARD_HAL_I2C1_SDA_PIN  GPIO_NUM_39
-#define BOARD_HAL_I2C1_SCL_PIN  GPIO_NUM_40
+#define BOARD_HAL_I2C1_SDA_PIN GPIO_NUM_39
+#define BOARD_HAL_I2C1_SCL_PIN GPIO_NUM_40
 
 // Battery ADC
-#define BOARD_HAL_BAT_ADC_PIN   ADC_CHANNEL_0  // GPIO1
-#define BOARD_HAL_BAT_EN_PIN    GPIO_NUM_21     // VBAT_EN (TPS22916 ADC enable)
+#define BOARD_HAL_BAT_ADC_PIN ADC_CHANNEL_0  // GPIO1
+#define BOARD_HAL_BAT_EN_PIN GPIO_NUM_21     // VBAT_EN (TPS22916 ADC enable)
 
 // Power Management
-#define BOARD_HAL_POWER_EN_PIN  GPIO_NUM_46     // System power enable
-#define BOARD_HAL_SY_INT_PIN    GPIO_NUM_47     // SY6974B charger interrupt
+#define BOARD_HAL_POWER_EN_PIN GPIO_NUM_46  // System power enable
+#define BOARD_HAL_SY_INT_PIN GPIO_NUM_47    // SY6974B charger interrupt
 
 // Buzzer
-#define BOARD_HAL_BUZZER_PIN    GPIO_NUM_45
+#define BOARD_HAL_BUZZER_PIN GPIO_NUM_45
 
 // Onboard Status LED (active-high)
-#define BOARD_HAL_LED_PIN       GPIO_NUM_48
-#define BOARD_HAL_LED_INVERTED  false
+#define BOARD_HAL_LED_PIN GPIO_NUM_48
+#define BOARD_HAL_LED_INVERTED false
 
 // Display Configuration
 #define BOARD_HAL_DISPLAY_ROTATION_DEG 0

--- a/components/board_hal/src/driver_seeedstudio_reterminal_e1004.c
+++ b/components/board_hal/src/driver_seeedstudio_reterminal_e1004.c
@@ -11,6 +11,7 @@
 #include "freertos/task.h"
 #include "pcf8563.h"
 #include "sensor.h"
+#include "sy6974b.h"
 
 #ifdef CONFIG_HAS_SDCARD
 #include "sdcard.h"
@@ -22,48 +23,11 @@ static const char *TAG = "board_hal_reterminal_e1004";
 static i2c_master_bus_handle_t i2c0_bus = NULL;  // charger + RTC + sensor
 static i2c_master_bus_handle_t i2c1_bus = NULL;  // touch buttons
 
-// SY6974B I2C address
-#define SY6974B_I2C_ADDR 0x6B
-
-// SY6974B register definitions
-#define SY6974B_REG_STATUS 0x08  // System status register
-#define SY6974B_VBUS_STAT_MASK 0xC0
-#define SY6974B_CHRG_STAT_MASK 0x18
-
-static i2c_master_dev_handle_t sy6974b_dev = NULL;
-
 // Battery measurement
 #define VBAT_ADC_CHANNEL BOARD_HAL_BAT_ADC_PIN
 #define VBAT_VOLTAGE_DIVIDER 2.0f  // 100k/100k resistor divider
 
 static adc_oneshot_unit_handle_t adc_handle = NULL;
-
-// ----------------------------------------------------------------
-// SY6974B helpers
-// ----------------------------------------------------------------
-
-static esp_err_t sy6974b_read_reg(uint8_t reg, uint8_t *val)
-{
-    if (!sy6974b_dev)
-        return ESP_ERR_INVALID_STATE;
-    esp_err_t ret = i2c_master_transmit_receive(sy6974b_dev, &reg, 1, val, 1, pdMS_TO_TICKS(100));
-    return ret;
-}
-
-static esp_err_t sy6974b_init(i2c_master_bus_handle_t bus)
-{
-    i2c_device_config_t dev_cfg = {
-        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
-        .device_address = SY6974B_I2C_ADDR,
-        .scl_speed_hz = 100000,
-    };
-    esp_err_t ret = i2c_master_bus_add_device(bus, &dev_cfg, &sy6974b_dev);
-    if (ret != ESP_OK) {
-        ESP_LOGW(TAG, "SY6974B not found: %s", esp_err_to_name(ret));
-        sy6974b_dev = NULL;
-    }
-    return ret;
-}
 
 // ----------------------------------------------------------------
 // Battery ADC
@@ -149,24 +113,14 @@ esp_err_t board_hal_init(void)
     };
     epaper_init(&ep_cfg);
 
-    // --- SD Card with power gating (TPS22916) ---
+    // --- SD Card with power gating via TPS22916 (handled by sdcard module) ---
 #ifdef CONFIG_HAS_SDCARD
-    gpio_config_t sd_pwr_cfg = {
-        .pin_bit_mask = (1ULL << BOARD_HAL_SD_PWR_PIN),
-        .mode = GPIO_MODE_OUTPUT,
-    };
-    gpio_config(&sd_pwr_cfg);
-    gpio_set_level(BOARD_HAL_SD_PWR_PIN, 1);
-    ESP_LOGI(TAG, "SD Card Power ON");
-
-    // Give SD card time to power up and stabilize
-    vTaskDelay(pdMS_TO_TICKS(500));
-
     ESP_LOGI(TAG, "Initializing SD card (SPI)...");
     sdcard_config_t sd_cfg = {
         .mount_point = "/storage",
         .host_id = SPI2_HOST,
         .cs_pin = BOARD_HAL_SD_CS_PIN,
+        .power_en_pin = BOARD_HAL_SD_PWR_PIN,
     };
 
     esp_err_t sd_ret = sdcard_init(&sd_cfg);
@@ -215,9 +169,7 @@ esp_err_t board_hal_init(void)
     esp_err_t i2c_ret = i2c_new_master_bus(&i2c0_bus_config, &i2c0_bus);
     if (i2c_ret == ESP_OK) {
         // Initialize SY6974B charger
-        if (sy6974b_init(i2c0_bus) == ESP_OK) {
-            ESP_LOGI(TAG, "SY6974B charger initialized");
-        }
+        sy6974b_init(i2c0_bus);
 
         // Initialize SHT40 temperature/humidity sensor
         if (sensor_init(i2c0_bus) == ESP_OK) {
@@ -262,9 +214,9 @@ esp_err_t board_hal_prepare_for_sleep(void)
     // Put display to deep sleep
     epaper_enter_deepsleep();
 
-    // Turn off SD power (TPS22916)
+    // Deinit SD card (powers off TPS22916 via sdcard module)
 #ifdef CONFIG_HAS_SDCARD
-    gpio_set_level(BOARD_HAL_SD_PWR_PIN, 0);
+    sdcard_deinit();
 #endif
 
     // Disable battery ADC measurement
@@ -342,30 +294,12 @@ int board_hal_get_battery_percent(void)
 
 bool board_hal_is_charging(void)
 {
-    if (!sy6974b_dev)
-        return false;
-
-    uint8_t status = 0;
-    if (sy6974b_read_reg(SY6974B_REG_STATUS, &status) != ESP_OK)
-        return false;
-
-    // CHRG_STAT bits [4:3]: 00=not charging, 01=pre-charge, 10=fast charging, 11=done
-    uint8_t chrg_stat = (status & SY6974B_CHRG_STAT_MASK) >> 3;
-    return (chrg_stat == 0x01 || chrg_stat == 0x02);
+    return sy6974b_is_charging();
 }
 
 bool board_hal_is_usb_connected(void)
 {
-    if (sy6974b_dev) {
-        uint8_t status = 0;
-        if (sy6974b_read_reg(SY6974B_REG_STATUS, &status) == ESP_OK) {
-            // VBUS_STAT bits [7:6]: 00=no input, 01=USB SDP, 10=USB CDP, 11=USB DCP
-            uint8_t vbus_stat = (status & SY6974B_VBUS_STAT_MASK) >> 6;
-            return (vbus_stat != 0);
-        }
-    }
-    // Fallback to USB serial JTAG detection
-    return usb_serial_jtag_is_connected();
+    return sy6974b_is_usb_connected();
 }
 
 void board_hal_shutdown(void)

--- a/components/board_hal/src/driver_seeedstudio_reterminal_e1004.c
+++ b/components/board_hal/src/driver_seeedstudio_reterminal_e1004.c
@@ -1,0 +1,427 @@
+#include "board_hal.h"
+#include "driver/gpio.h"
+#include "driver/i2c_master.h"
+#include "driver/spi_master.h"
+#include "driver/usb_serial_jtag.h"
+#include "epaper.h"
+#include "esp_adc/adc_oneshot.h"
+#include "esp_log.h"
+#include "esp_sleep.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "pcf8563.h"
+#include "sensor.h"
+
+#ifdef CONFIG_HAS_SDCARD
+#include "sdcard.h"
+#endif
+
+static const char *TAG = "board_hal_reterminal_e1004";
+
+// I2C bus handles
+static i2c_master_bus_handle_t i2c0_bus = NULL;  // charger + RTC + sensor
+static i2c_master_bus_handle_t i2c1_bus = NULL;  // touch buttons
+
+// SY6974B I2C address
+#define SY6974B_I2C_ADDR  0x6B
+
+// SY6974B register definitions
+#define SY6974B_REG_STATUS  0x08  // System status register
+#define SY6974B_VBUS_STAT_MASK  0xC0
+#define SY6974B_CHRG_STAT_MASK  0x18
+
+static i2c_master_dev_handle_t sy6974b_dev = NULL;
+
+// Battery measurement
+#define VBAT_ADC_CHANNEL    BOARD_HAL_BAT_ADC_PIN
+#define VBAT_VOLTAGE_DIVIDER 2.0f  // 100k/100k resistor divider
+
+static adc_oneshot_unit_handle_t adc_handle = NULL;
+
+// ----------------------------------------------------------------
+// SY6974B helpers
+// ----------------------------------------------------------------
+
+static esp_err_t sy6974b_read_reg(uint8_t reg, uint8_t *val)
+{
+    if (!sy6974b_dev)
+        return ESP_ERR_INVALID_STATE;
+    esp_err_t ret = i2c_master_transmit_receive(sy6974b_dev, &reg, 1, val, 1, pdMS_TO_TICKS(100));
+    return ret;
+}
+
+static esp_err_t sy6974b_init(i2c_master_bus_handle_t bus)
+{
+    i2c_device_config_t dev_cfg = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = SY6974B_I2C_ADDR,
+        .scl_speed_hz = 100000,
+    };
+    esp_err_t ret = i2c_master_bus_add_device(bus, &dev_cfg, &sy6974b_dev);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "SY6974B not found: %s", esp_err_to_name(ret));
+        sy6974b_dev = NULL;
+    }
+    return ret;
+}
+
+// ----------------------------------------------------------------
+// Battery ADC
+// ----------------------------------------------------------------
+
+static void board_hal_battery_adc_init(void)
+{
+    if (adc_handle)
+        return;
+
+    adc_oneshot_unit_init_cfg_t init_config = {
+        .unit_id = ADC_UNIT_1,  // GPIO1 = ADC1 Channel 0
+        .clk_src = ADC_DIGI_CLK_SRC_DEFAULT,
+    };
+
+    esp_err_t ret = adc_oneshot_new_unit(&init_config, &adc_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "ADC init failed: %s", esp_err_to_name(ret));
+        return;
+    }
+
+    adc_oneshot_chan_cfg_t config = {
+        .bitwidth = ADC_BITWIDTH_DEFAULT,
+        .atten = ADC_ATTEN_DB_12,
+    };
+    ret = adc_oneshot_config_channel(adc_handle, VBAT_ADC_CHANNEL, &config);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "ADC channel config failed: %s", esp_err_to_name(ret));
+        adc_oneshot_del_unit(adc_handle);
+        adc_handle = NULL;
+    }
+}
+
+// ----------------------------------------------------------------
+// Board HAL API
+// ----------------------------------------------------------------
+
+esp_err_t board_hal_init(void)
+{
+    ESP_LOGI(TAG, "Initializing reTerminal E1004 Board HAL");
+
+    // --- System power enable ---
+    gpio_config_t pwr_cfg = {
+        .pin_bit_mask = (1ULL << BOARD_HAL_POWER_EN_PIN),
+        .mode = GPIO_MODE_OUTPUT,
+    };
+    gpio_config(&pwr_cfg);
+    gpio_set_level(BOARD_HAL_POWER_EN_PIN, 1);
+
+    // --- SPI bus ---
+    ESP_LOGI(TAG, "Initializing SPI bus...");
+
+    // Pull CS pins HIGH early to prevent interference on the shared bus
+    gpio_config_t cs_cfg = {
+        .pin_bit_mask = (1ULL << BOARD_HAL_EPD_CS_PIN) | (1ULL << BOARD_HAL_SD_CS_PIN),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+    };
+    gpio_config(&cs_cfg);
+    gpio_set_level(BOARD_HAL_EPD_CS_PIN, 1);
+    gpio_set_level(BOARD_HAL_SD_CS_PIN, 1);
+
+    spi_bus_config_t bus_cfg = {
+        .mosi_io_num = BOARD_HAL_SPI_MOSI_PIN,
+        .miso_io_num = BOARD_HAL_SPI_MISO_PIN,
+        .sclk_io_num = BOARD_HAL_SPI_SCLK_PIN,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        .max_transfer_sz = 4092,
+        .flags = SPICOMMON_BUSFLAG_MASTER | SPICOMMON_BUSFLAG_SCLK,
+    };
+    ESP_ERROR_CHECK(spi_bus_initialize(SPI2_HOST, &bus_cfg, SPI_DMA_CH_AUTO));
+
+    // --- E-Paper Display (ED2208 13.3" Spectra 6) ---
+    epaper_config_t ep_cfg = {
+        .spi_host = SPI2_HOST,
+        .pin_cs = BOARD_HAL_EPD_CS_PIN,
+        .pin_dc = BOARD_HAL_EPD_DC_PIN,
+        .pin_rst = BOARD_HAL_EPD_RST_PIN,
+        .pin_busy = BOARD_HAL_EPD_BUSY_PIN,
+        .pin_cs1 = -1,
+        .pin_enable = BOARD_HAL_EPD_ENABLE_PIN,
+    };
+    epaper_init(&ep_cfg);
+
+    // --- SD Card with power gating (TPS22916) ---
+#ifdef CONFIG_HAS_SDCARD
+    gpio_config_t sd_pwr_cfg = {
+        .pin_bit_mask = (1ULL << BOARD_HAL_SD_PWR_PIN),
+        .mode = GPIO_MODE_OUTPUT,
+    };
+    gpio_config(&sd_pwr_cfg);
+    gpio_set_level(BOARD_HAL_SD_PWR_PIN, 1);
+    ESP_LOGI(TAG, "SD Card Power ON");
+
+    // Give SD card time to power up and stabilize
+    vTaskDelay(pdMS_TO_TICKS(500));
+
+    ESP_LOGI(TAG, "Initializing SD card (SPI)...");
+    sdcard_config_t sd_cfg = {
+        .mount_point = "/storage",
+        .host_id = SPI2_HOST,
+        .cs_pin = BOARD_HAL_SD_CS_PIN,
+    };
+
+    esp_err_t sd_ret = sdcard_init(&sd_cfg);
+    if (sd_ret == ESP_OK) {
+        ESP_LOGI(TAG, "SD card initialized successfully");
+    } else {
+        ESP_LOGW(TAG, "SD card initialization failed: %s", esp_err_to_name(sd_ret));
+    }
+#endif
+
+    // --- Battery ADC (TPS22916 load switch on GPIO21) ---
+    gpio_config_t bat_en_cfg = {
+        .pin_bit_mask = (1ULL << BOARD_HAL_BAT_EN_PIN),
+        .mode = GPIO_MODE_OUTPUT,
+    };
+    gpio_config(&bat_en_cfg);
+    gpio_set_level(BOARD_HAL_BAT_EN_PIN, 0);  // Disable measurement by default
+
+    board_hal_battery_adc_init();
+
+    // --- Onboard Status LED (GPIO48, active-high) ---
+    gpio_config_t led_cfg = {
+        .pin_bit_mask = (1ULL << BOARD_HAL_LED_PIN),
+        .mode = GPIO_MODE_OUTPUT,
+    };
+    gpio_config(&led_cfg);
+    board_hal_led_set(BOARD_HAL_LED_ACTIVITY, false);
+
+    // --- Buzzer (GPIO45) ---
+    gpio_config_t buzzer_cfg = {
+        .pin_bit_mask = (1ULL << BOARD_HAL_BUZZER_PIN),
+        .mode = GPIO_MODE_OUTPUT,
+    };
+    gpio_config(&buzzer_cfg);
+    gpio_set_level(BOARD_HAL_BUZZER_PIN, 0);
+
+    // --- I2C Bus 0: SY6974B charger + PCF8563M RTC + SHT40 sensor ---
+    i2c_master_bus_config_t i2c0_bus_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = 0,
+        .scl_io_num = BOARD_HAL_I2C_SCL_PIN,
+        .sda_io_num = BOARD_HAL_I2C_SDA_PIN,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+    esp_err_t i2c_ret = i2c_new_master_bus(&i2c0_bus_config, &i2c0_bus);
+    if (i2c_ret == ESP_OK) {
+        // Initialize SY6974B charger
+        if (sy6974b_init(i2c0_bus) == ESP_OK) {
+            ESP_LOGI(TAG, "SY6974B charger initialized");
+        }
+
+        // Initialize SHT40 temperature/humidity sensor
+        if (sensor_init(i2c0_bus) == ESP_OK) {
+            ESP_LOGI(TAG, "SHT40 sensor initialized");
+        }
+
+        // Initialize PCF8563M RTC
+        if (pcf8563_init(i2c0_bus) == ESP_OK) {
+            ESP_LOGI(TAG, "PCF8563M RTC initialized");
+        }
+    } else {
+        ESP_LOGE(TAG, "Failed to initialize I2C bus 0: %s", esp_err_to_name(i2c_ret));
+    }
+
+    // --- I2C Bus 1: Touch buttons ---
+    i2c_master_bus_config_t i2c1_bus_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = 1,
+        .scl_io_num = BOARD_HAL_I2C1_SCL_PIN,
+        .sda_io_num = BOARD_HAL_I2C1_SDA_PIN,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+    i2c_ret = i2c_new_master_bus(&i2c1_bus_config, &i2c1_bus);
+    if (i2c_ret == ESP_OK) {
+        ESP_LOGI(TAG, "I2C bus 1 (touch) initialized");
+    } else {
+        ESP_LOGW(TAG, "Failed to initialize I2C bus 1: %s", esp_err_to_name(i2c_ret));
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t board_hal_prepare_for_sleep(void)
+{
+    ESP_LOGI(TAG, "Preparing reTerminal E1004 for sleep");
+
+    // Turn off LED and buzzer
+    board_hal_led_set(BOARD_HAL_LED_ACTIVITY, false);
+    gpio_set_level(BOARD_HAL_BUZZER_PIN, 0);
+
+    // Put display to deep sleep
+    epaper_enter_deepsleep();
+
+    // Turn off SD power (TPS22916)
+#ifdef CONFIG_HAS_SDCARD
+    gpio_set_level(BOARD_HAL_SD_PWR_PIN, 0);
+#endif
+
+    // Disable battery ADC measurement
+    gpio_set_level(BOARD_HAL_BAT_EN_PIN, 0);
+
+    // Free ADC resource
+    if (adc_handle) {
+        adc_oneshot_del_unit(adc_handle);
+        adc_handle = NULL;
+    }
+
+    return ESP_OK;
+}
+
+bool board_hal_is_battery_connected(void)
+{
+    return board_hal_get_battery_voltage() > 500;
+}
+
+int board_hal_get_battery_voltage(void)
+{
+    if (!adc_handle) {
+        board_hal_battery_adc_init();
+        if (!adc_handle)
+            return -1;
+    }
+
+    // Enable TPS22916 load switch to connect ADC divider
+    gpio_set_level(BOARD_HAL_BAT_EN_PIN, 1);
+    vTaskDelay(pdMS_TO_TICKS(10));
+
+    int adc_raw;
+    esp_err_t ret = adc_oneshot_read(adc_handle, VBAT_ADC_CHANNEL, &adc_raw);
+
+    // Disable measurement
+    gpio_set_level(BOARD_HAL_BAT_EN_PIN, 0);
+
+    if (ret == ESP_OK) {
+        // Voltage = raw * (3300 / 4095) * divider
+        float voltage_mv = (float) adc_raw * (3300.0f / 4095.0f) * VBAT_VOLTAGE_DIVIDER;
+        return (int) voltage_mv;
+    }
+    return -1;
+}
+
+int board_hal_get_battery_percent(void)
+{
+    int voltage = board_hal_get_battery_voltage();
+    if (voltage < 0)
+        return -1;
+
+    // LiPo discharge curve calibration
+    static const struct {
+        int mv;
+        int pct;
+    } cal[] = {
+        {4150, 100}, {3960, 90}, {3910, 80}, {3850, 70}, {3800, 60}, {3750, 50},
+        {3680, 40},  {3580, 30}, {3490, 20}, {3410, 10}, {3300, 5},  {3270, 0},
+    };
+
+    if (voltage >= cal[0].mv)
+        return 100;
+    if (voltage <= cal[sizeof(cal) / sizeof(cal[0]) - 1].mv)
+        return 0;
+
+    for (int i = 0; i < (int) (sizeof(cal) / sizeof(cal[0])) - 1; i++) {
+        if (voltage >= cal[i + 1].mv) {
+            int dv = cal[i].mv - cal[i + 1].mv;
+            int dp = cal[i].pct - cal[i + 1].pct;
+            return cal[i + 1].pct + (voltage - cal[i + 1].mv) * dp / dv;
+        }
+    }
+    return 0;
+}
+
+bool board_hal_is_charging(void)
+{
+    if (!sy6974b_dev)
+        return false;
+
+    uint8_t status = 0;
+    if (sy6974b_read_reg(SY6974B_REG_STATUS, &status) != ESP_OK)
+        return false;
+
+    // CHRG_STAT bits [4:3]: 00=not charging, 01=pre-charge, 10=fast charging, 11=done
+    uint8_t chrg_stat = (status & SY6974B_CHRG_STAT_MASK) >> 3;
+    return (chrg_stat == 0x01 || chrg_stat == 0x02);
+}
+
+bool board_hal_is_usb_connected(void)
+{
+    if (sy6974b_dev) {
+        uint8_t status = 0;
+        if (sy6974b_read_reg(SY6974B_REG_STATUS, &status) == ESP_OK) {
+            // VBUS_STAT bits [7:6]: 00=no input, 01=USB SDP, 10=USB CDP, 11=USB DCP
+            uint8_t vbus_stat = (status & SY6974B_VBUS_STAT_MASK) >> 6;
+            return (vbus_stat != 0);
+        }
+    }
+    // Fallback to USB serial JTAG detection
+    return usb_serial_jtag_is_connected();
+}
+
+void board_hal_shutdown(void)
+{
+    ESP_LOGI(TAG, "Shutdown requested, entering deep sleep");
+    board_hal_prepare_for_sleep();
+    // De-assert system power enable
+    gpio_set_level(BOARD_HAL_POWER_EN_PIN, 0);
+    esp_deep_sleep_start();
+}
+
+esp_err_t board_hal_rtc_init(void)
+{
+    return pcf8563_is_available() ? ESP_OK : ESP_ERR_NOT_FOUND;
+}
+
+esp_err_t board_hal_rtc_get_time(time_t *t)
+{
+    return pcf8563_read_time(t);
+}
+
+esp_err_t board_hal_rtc_set_time(time_t t)
+{
+    return pcf8563_write_time(t);
+}
+
+bool board_hal_rtc_is_available(void)
+{
+    return pcf8563_is_available();
+}
+
+void board_hal_led_set(board_hal_led_t led, bool on)
+{
+    // E1004 has a single status LED on GPIO48
+    (void) led;
+    gpio_set_level(BOARD_HAL_LED_PIN, BOARD_HAL_LED_INVERTED ? !on : on);
+}
+
+esp_err_t board_hal_get_temperature(float *t)
+{
+    if (!t)
+        return ESP_ERR_INVALID_ARG;
+    if (!sensor_is_available())
+        return ESP_ERR_INVALID_STATE;
+
+    float h_dummy;
+    return sensor_read(t, &h_dummy);
+}
+
+esp_err_t board_hal_get_humidity(float *h)
+{
+    if (!h)
+        return ESP_ERR_INVALID_ARG;
+    if (!sensor_is_available())
+        return ESP_ERR_INVALID_STATE;
+
+    float t_dummy;
+    return sensor_read(&t_dummy, h);
+}

--- a/components/board_hal/src/driver_seeedstudio_reterminal_e1004.c
+++ b/components/board_hal/src/driver_seeedstudio_reterminal_e1004.c
@@ -23,17 +23,17 @@ static i2c_master_bus_handle_t i2c0_bus = NULL;  // charger + RTC + sensor
 static i2c_master_bus_handle_t i2c1_bus = NULL;  // touch buttons
 
 // SY6974B I2C address
-#define SY6974B_I2C_ADDR  0x6B
+#define SY6974B_I2C_ADDR 0x6B
 
 // SY6974B register definitions
-#define SY6974B_REG_STATUS  0x08  // System status register
-#define SY6974B_VBUS_STAT_MASK  0xC0
-#define SY6974B_CHRG_STAT_MASK  0x18
+#define SY6974B_REG_STATUS 0x08  // System status register
+#define SY6974B_VBUS_STAT_MASK 0xC0
+#define SY6974B_CHRG_STAT_MASK 0x18
 
 static i2c_master_dev_handle_t sy6974b_dev = NULL;
 
 // Battery measurement
-#define VBAT_ADC_CHANNEL    BOARD_HAL_BAT_ADC_PIN
+#define VBAT_ADC_CHANNEL BOARD_HAL_BAT_ADC_PIN
 #define VBAT_VOLTAGE_DIVIDER 2.0f  // 100k/100k resistor divider
 
 static adc_oneshot_unit_handle_t adc_handle = NULL;

--- a/components/pmic_driver_sy6974b/CMakeLists.txt
+++ b/components/pmic_driver_sy6974b/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRC_DIRS "src"
     INCLUDE_DIRS "include"
-    REQUIRES driver esp_driver_gpio esp_driver_i2c esp_driver_usb_serial_jtag
+    REQUIRES driver esp_driver_gpio esp_driver_i2c
 )

--- a/components/pmic_driver_sy6974b/CMakeLists.txt
+++ b/components/pmic_driver_sy6974b/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRC_DIRS "src"
+    INCLUDE_DIRS "include"
+    REQUIRES driver esp_driver_gpio esp_driver_i2c
+)

--- a/components/pmic_driver_sy6974b/CMakeLists.txt
+++ b/components/pmic_driver_sy6974b/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRC_DIRS "src"
     INCLUDE_DIRS "include"
-    REQUIRES driver esp_driver_gpio esp_driver_i2c
+    REQUIRES driver esp_driver_gpio esp_driver_i2c esp_driver_usb_serial_jtag
 )

--- a/components/pmic_driver_sy6974b/Kconfig
+++ b/components/pmic_driver_sy6974b/Kconfig
@@ -1,0 +1,9 @@
+menu "SY6974B Power Management"
+
+    config PMIC_DRIVER_SY6974B
+        bool
+        default n
+        help
+            Selected by board drivers that require SY6974B PMIC support.
+
+endmenu

--- a/components/pmic_driver_sy6974b/include/sy6974b.h
+++ b/components/pmic_driver_sy6974b/include/sy6974b.h
@@ -1,0 +1,24 @@
+#ifndef SY6974B_H
+#define SY6974B_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "driver/i2c_master.h"
+
+void sy6974b_init(i2c_master_bus_handle_t i2c_bus);
+int sy6974b_get_battery_percent(void);
+int sy6974b_get_battery_voltage(void);
+bool sy6974b_is_charging(void);
+bool sy6974b_is_battery_connected(void);
+bool sy6974b_is_usb_connected(void);
+void sy6974b_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/components/pmic_driver_sy6974b/src/sy6974b.c
+++ b/components/pmic_driver_sy6974b/src/sy6974b.c
@@ -1,7 +1,6 @@
 #include "sy6974b.h"
 
 #include "driver/i2c_master.h"
-#include "driver/usb_serial_jtag.h"
 #include "esp_log.h"
 
 static const char *TAG = "pmic_sy6974b";
@@ -81,8 +80,8 @@ bool sy6974b_is_usb_connected(void)
             return (vbus_stat != 0);
         }
     }
-    // Fallback to USB serial JTAG detection
-    return usb_serial_jtag_is_connected();
+    // No I2C device or read failed — assume not connected
+    return false;
 }
 
 void sy6974b_shutdown(void)

--- a/components/pmic_driver_sy6974b/src/sy6974b.c
+++ b/components/pmic_driver_sy6974b/src/sy6974b.c
@@ -1,0 +1,92 @@
+#include "sy6974b.h"
+
+#include "driver/i2c_master.h"
+#include "driver/usb_serial_jtag.h"
+#include "esp_log.h"
+
+static const char *TAG = "pmic_sy6974b";
+
+// SY6974B I2C address
+#define SY6974B_I2C_ADDR 0x6B
+
+// SY6974B register definitions
+#define SY6974B_REG_STATUS 0x08  // System status register
+#define SY6974B_VBUS_STAT_MASK 0xC0
+#define SY6974B_CHRG_STAT_MASK 0x18
+
+static i2c_master_dev_handle_t sy6974b_dev = NULL;
+
+static esp_err_t sy6974b_read_reg(uint8_t reg, uint8_t *val)
+{
+    if (!sy6974b_dev)
+        return ESP_ERR_INVALID_STATE;
+    return i2c_master_transmit_receive(sy6974b_dev, &reg, 1, val, 1, pdMS_TO_TICKS(100));
+}
+
+void sy6974b_init(i2c_master_bus_handle_t i2c_bus)
+{
+    i2c_device_config_t dev_cfg = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = SY6974B_I2C_ADDR,
+        .scl_speed_hz = 100000,
+    };
+    esp_err_t ret = i2c_master_bus_add_device(i2c_bus, &dev_cfg, &sy6974b_dev);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "SY6974B not found: %s", esp_err_to_name(ret));
+        sy6974b_dev = NULL;
+    } else {
+        ESP_LOGI(TAG, "SY6974B initialized");
+    }
+}
+
+int sy6974b_get_battery_voltage(void)
+{
+    // Voltage measurement is handled by board-level ADC; not available here
+    return -1;
+}
+
+int sy6974b_get_battery_percent(void)
+{
+    // Percentage estimation is handled by board-level ADC; not available here
+    return -1;
+}
+
+bool sy6974b_is_battery_connected(void)
+{
+    // Battery connection check is handled by board-level ADC; not available here
+    return false;
+}
+
+bool sy6974b_is_charging(void)
+{
+    if (!sy6974b_dev)
+        return false;
+
+    uint8_t status = 0;
+    if (sy6974b_read_reg(SY6974B_REG_STATUS, &status) != ESP_OK)
+        return false;
+
+    // CHRG_STAT bits [4:3]: 00=not charging, 01=pre-charge, 10=fast charging, 11=done
+    uint8_t chrg_stat = (status & SY6974B_CHRG_STAT_MASK) >> 3;
+    return (chrg_stat == 0x01 || chrg_stat == 0x02);
+}
+
+bool sy6974b_is_usb_connected(void)
+{
+    if (sy6974b_dev) {
+        uint8_t status = 0;
+        if (sy6974b_read_reg(SY6974B_REG_STATUS, &status) == ESP_OK) {
+            // VBUS_STAT bits [7:6]: 00=no input, 01=USB SDP, 10=USB CDP, 11=USB DCP
+            uint8_t vbus_stat = (status & SY6974B_VBUS_STAT_MASK) >> 6;
+            return (vbus_stat != 0);
+        }
+    }
+    // Fallback to USB serial JTAG detection
+    return usb_serial_jtag_is_connected();
+}
+
+void sy6974b_shutdown(void)
+{
+    // Shutdown is handled at board level (de-assert power enable pin)
+    ESP_LOGI(TAG, "SY6974B shutdown requested");
+}

--- a/components/sdcard/include/sdcard.h
+++ b/components/sdcard/include/sdcard.h
@@ -15,6 +15,7 @@ extern "C" {
  */
 typedef struct {
     const char *mount_point;
+    gpio_num_t power_en_pin;  // GPIO for power enable (e.g. TPS22916), -1 if not used
 #ifdef CONFIG_SDCARD_DRIVER_SPI
     int host_id;
     gpio_num_t cs_pin;
@@ -43,6 +44,11 @@ esp_err_t sdcard_init(const sdcard_config_t *config);
  * @return true if mounted, false otherwise
  */
 bool sdcard_is_mounted(void);
+
+/**
+ * @brief Deinitialize SD card and cut power if power_en_pin is configured
+ */
+void sdcard_deinit(void);
 
 #ifdef __cplusplus
 }

--- a/components/sdcard/src/sdcard_sdio.c
+++ b/components/sdcard/src/sdcard_sdio.c
@@ -1,19 +1,37 @@
+#include "driver/gpio.h"
 #include "driver/sdmmc_host.h"
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_vfs_fat.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "sdcard.h"
 #include "sdmmc_cmd.h"
 
 static const char *TAG = "sdcard_sdio";
 
 sdmmc_card_t *card_host = NULL;
+static gpio_num_t s_power_en_pin = -1;
 
 esp_err_t sdcard_init(const sdcard_config_t *config)
 {
     if (!config) {
         ESP_LOGE(TAG, "Invalid configuration");
         return ESP_ERR_INVALID_ARG;
+    }
+
+    s_power_en_pin = config->power_en_pin;
+
+    // Power up SD card if a power enable pin is configured
+    if (s_power_en_pin >= 0) {
+        gpio_config_t pwr_cfg = {
+            .pin_bit_mask = (1ULL << s_power_en_pin),
+            .mode = GPIO_MODE_OUTPUT,
+        };
+        gpio_config(&pwr_cfg);
+        gpio_set_level(s_power_en_pin, 1);
+        ESP_LOGI(TAG, "SD card power enabled (GPIO%d)", s_power_en_pin);
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
 
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
@@ -67,4 +85,17 @@ esp_err_t sdcard_init(const sdcard_config_t *config)
 bool sdcard_is_mounted(void)
 {
     return card_host != NULL;
+}
+
+void sdcard_deinit(void)
+{
+    if (card_host) {
+        esp_vfs_fat_sdcard_unmount("/sdcard", card_host);
+        card_host = NULL;
+    }
+    // Cut power to SD card to save power
+    if (s_power_en_pin >= 0) {
+        gpio_set_level(s_power_en_pin, 0);
+        ESP_LOGI(TAG, "SD card power disabled (GPIO%d)", s_power_en_pin);
+    }
 }

--- a/components/sdcard/src/sdcard_sdio.c
+++ b/components/sdcard/src/sdcard_sdio.c
@@ -23,7 +23,7 @@ esp_err_t sdcard_init(const sdcard_config_t *config)
     s_power_en_pin = config->power_en_pin;
 
     // Power up SD card if a power enable pin is configured
-    if (s_power_en_pin >= 0) {
+    if (s_power_en_pin > 0) {
         gpio_config_t pwr_cfg = {
             .pin_bit_mask = (1ULL << s_power_en_pin),
             .mode = GPIO_MODE_OUTPUT,
@@ -94,7 +94,7 @@ void sdcard_deinit(void)
         card_host = NULL;
     }
     // Cut power to SD card to save power
-    if (s_power_en_pin >= 0) {
+    if (s_power_en_pin > 0) {
         gpio_set_level(s_power_en_pin, 0);
         ESP_LOGI(TAG, "SD card power disabled (GPIO%d)", s_power_en_pin);
     }

--- a/components/sdcard/src/sdcard_spi.c
+++ b/components/sdcard/src/sdcard_spi.c
@@ -1,19 +1,37 @@
+#include "driver/gpio.h"
 #include "driver/sdspi_host.h"
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_vfs_fat.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "sdcard.h"
 #include "sdmmc_cmd.h"
 
 static const char *TAG = "sdcard_spi";
 
 sdmmc_card_t *card_host = NULL;
+static gpio_num_t s_power_en_pin = -1;
 
 esp_err_t sdcard_init(const sdcard_config_t *config)
 {
     if (!config) {
         ESP_LOGE(TAG, "Invalid configuration");
         return ESP_ERR_INVALID_ARG;
+    }
+
+    s_power_en_pin = config->power_en_pin;
+
+    // Power up SD card if a power enable pin is configured
+    if (s_power_en_pin >= 0) {
+        gpio_config_t pwr_cfg = {
+            .pin_bit_mask = (1ULL << s_power_en_pin),
+            .mode = GPIO_MODE_OUTPUT,
+        };
+        gpio_config(&pwr_cfg);
+        gpio_set_level(s_power_en_pin, 1);
+        ESP_LOGI(TAG, "SD card power enabled (GPIO%d)", s_power_en_pin);
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
 
     esp_vfs_fat_sdmmc_mount_config_t mount_config = {
@@ -59,4 +77,17 @@ esp_err_t sdcard_init(const sdcard_config_t *config)
 bool sdcard_is_mounted(void)
 {
     return card_host != NULL;
+}
+
+void sdcard_deinit(void)
+{
+    if (card_host) {
+        esp_vfs_fat_sdcard_unmount("/sdcard", card_host);
+        card_host = NULL;
+    }
+    // Cut power to SD card to save power
+    if (s_power_en_pin >= 0) {
+        gpio_set_level(s_power_en_pin, 0);
+        ESP_LOGI(TAG, "SD card power disabled (GPIO%d)", s_power_en_pin);
+    }
 }

--- a/components/sdcard/src/sdcard_spi.c
+++ b/components/sdcard/src/sdcard_spi.c
@@ -23,7 +23,7 @@ esp_err_t sdcard_init(const sdcard_config_t *config)
     s_power_en_pin = config->power_en_pin;
 
     // Power up SD card if a power enable pin is configured
-    if (s_power_en_pin >= 0) {
+    if (s_power_en_pin > 0) {
         gpio_config_t pwr_cfg = {
             .pin_bit_mask = (1ULL << s_power_en_pin),
             .mode = GPIO_MODE_OUTPUT,
@@ -86,7 +86,7 @@ void sdcard_deinit(void)
         card_host = NULL;
     }
     // Cut power to SD card to save power
-    if (s_power_en_pin >= 0) {
+    if (s_power_en_pin > 0) {
         gpio_set_level(s_power_en_pin, 0);
         ESP_LOGI(TAG, "SD card power disabled (GPIO%d)", s_power_en_pin);
     }


### PR DESCRIPTION
## Summary

Adds board HAL support for the Seeed reTerminal E1004, which features a 13.3" ED2208 Spectra 6 e-paper display (same as EE02) with a significantly different board design.

## New hardware support

- **Display:** ED2208 13.3" Spectra 6 (60-pin FPC, reuses existing EP_DRIVER_ED2208_GCA)
- **MCU:** ESP32-S3R8 (8MB Octal PSRAM)
- **PMIC:** SY6974B I2C charger (address 0x6B on I2C0) — replaces AXP2101
- **RTC:** PCF8563M (address 0x51 on I2C0)
- **Sensor:** SHT40 temperature/humidity (address 0x44 on I2C0)
- **SD card:** SPI with TPS22916 power gating (GPIO16)
- **Battery ADC:** GPIO1 (ADC1_CH0) with TPS22916 load switch on GPIO21
- **Dual I2C buses:** I2C0 (GPIO19/20) for peripherals, I2C1 (GPIO39/40) for touch buttons
- **Buzzer:** GPIO45
- **Status LED:** GPIO48 (active-high)
- **3 physical buttons** (GPIO3/4/5) + 3 I2C touch buttons via I2C1
- **Expansion port:** 5-pin GH 1.25mm (GND, 3V3, SDA, SCL, GPIO6)

## Files changed

-  — pin definitions
-  — board driver
-  — add BOARD_TYPE_SEEEDSTUDIO_RETERMINAL_E1004 and include guard
-  — add BOARD_DRIVER_SEEEDSTUDIO_RETERMINAL_E1004 config option

Fixes #44