### PR TITLE
Fix white color mapping on GC16 grayscale boards (E1002/E1003/E1004)

### DIFF
--- a/components/epaper_src/CMakeLists.txt
+++ b/components/epaper_src/CMakeLists.txt
@@ -8,7 +8,7 @@ set(include_dirs
 idf_component_register(
   SRC_DIRS 
   ${src_dirs}
-  PRIV_REQUIRES driver fatfs espressif__libpng espressif__zlib
+  PRIV_REQUIRES driver fatfs espressif__libpng espressif__zlib board_hal
   INCLUDE_DIRS 
   ${include_dirs})
 

--- a/components/epaper_src/GUI_PNGfile.c
+++ b/components/epaper_src/GUI_PNGfile.c
@@ -3,8 +3,10 @@
 #include <esp_log.h>
 #include <png.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "GUI_Paint.h"
+#include "board_hal.h"
 
 static const char *TAG = "GUI_PNGfile";
 
@@ -116,6 +118,20 @@ UBYTE GUI_ReadPng_RGB_6Color(const char *path, UWORD Xstart, UWORD Ystart)
     // Process image row by row
     ESP_LOGI(TAG, "PNG decoded successfully");
 
+    // Paint_SetPixel packs whatever value it's given directly as a 4-bit
+    // pixel nibble with no board-specific translation. The color/index
+    // scheme below (0=Black, 1=White, ...) is correct as-is for a 6-color
+    // Spectra panel, where small integers are genuine hardware ink-color
+    // indices. On a native grayscale panel (GC16/IT8951) those same nibbles
+    // are linear intensity 0..15 (0=black, 15=white per the IT8951 driver),
+    // so passing index 1 for "white" renders as near-black instead. Only
+    // White needs correcting: Black is 0 in both schemes, and the other
+    // four colors have no meaningful grayscale equivalent (a pure grayscale
+    // panel can't render them) and are not expected to appear in content
+    // authored for a grayscale board.
+    bool is_grayscale_board = (strcmp(BOARD_HAL_DISPLAY_TYPE, "gc16") == 0);
+    UBYTE white = is_grayscale_board ? 15 : 1;
+
     for (int y = 0; y < height; y++) {
         png_read_row(png_ptr, (png_bytep) rgb_buffer, NULL);
 
@@ -134,7 +150,7 @@ UBYTE GUI_ReadPng_RGB_6Color(const char *path, UWORD Xstart, UWORD Ystart)
             if (r == 0 && g == 0 && b == 0) {
                 color = 0;  // Black
             } else if (r == 255 && g == 255 && b == 255) {
-                color = 1;  // White
+                color = white;  // White
             } else if (r == 255 && g == 255 && b == 0) {
                 color = 2;  // Yellow
             } else if (r == 255 && g == 0 && b == 0) {
@@ -144,7 +160,7 @@ UBYTE GUI_ReadPng_RGB_6Color(const char *path, UWORD Xstart, UWORD Ystart)
             } else if (r == 0 && g == 255 && b == 0) {
                 color = 6;  // Green
             } else {
-                color = 1;  // Default to white for unknown colors
+                color = white;  // Default to white for unknown colors
             }
 
             // Paint pixel directly (Paint rotation system handles coordinate transformations)


### PR DESCRIPTION
## Problem

`GUI_ReadPng_RGB_6Color` (`components/epaper_src/GUI_PNGfile.c`) maps decoded PNG pixel colors to small integer indices designed for the 6-color Spectra-style panel used by other boards in this project. `Paint_SetPixel` packs that index directly as a 4-bit pixel nibble with no board-specific translation.

On grayscale GC16/IT8951 boards (E1002/E1003/E1004), those nibbles are a linear 0–15 intensity scale (0=black, 15=white), not Spectra color indices. The current code maps White to index `1`, which renders as near-black on a grayscale panel instead of white. Black happens to be `0` in both schemes, so it was already correct — only White is wrong. This affects any full-resolution custom image that isn't pure black, on any grayscale board using this fast decode path (e.g. URL rotation mode).

## Fix

When `BOARD_HAL_DISPLAY_TYPE == "gc16"`, map White to nibble `15` instead of `1`. Black is untouched. The other four Spectra colors (Yellow/Red/Blue/Green) are left as-is — no meaningful grayscale equivalent, not expected in content authored for a grayscale board.

## Testing

Verified live on a physical reTerminal E1003: before the fix, a black-text-on-white PNG rendered almost entirely black; after, it displays with a correct white background and legible black text.
