### PR TITLE
Add native Telegram Bot rotation mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,13 @@ demo/waveshare_photopainter_73
 demo/seeedstudio_xiao_ee02
 demo/seeedstudio_xiao_ee04
 demo/seeedstudio_reterminal_e1002
+
+# Local-only debug artifacts - device coredumps/logs can contain WiFi/device
+# details and must never be committed; never commit these.
+photoframe-debug*.log*
+CoreDUMP*.7z
+_BuildCMD.txt
+
+# Local editor/tool configs - not project-wide settings
+.claude/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modern, feature-rich firmware for ESP32-based e-paper photo frames (currently 
 - 🎨 **Superior Image Quality**: Measured color palette with automatic calibration produces significantly better results than stock firmware
 - 🔋 **Smart Power Management**: Deep sleep mode for weeks of battery life, or always-on for Home Assistant
 - 📁 **Flexible Image Sources**: SD card rotation, URL-based fetching (weather, news, random images from image server)
+- 🤖 **Telegram Bot**: Send photos straight to the frame via a Telegram bot, no extra server required ([docs](docs/TELEGRAM.md))
 - 🌐 **Modern Web Interface**: Drag-and-drop uploads, gallery view, real-time battery status
 - 📱 **Mobile App**: [Companion app](https://github.com/aitjcize/esp32-photoframe-app) for WiFi provisioning, image processing, and AI generation
 - 🖼️ **Image Server**: [Companion server](https://github.com/aitjcize/esp32-photoframe-server) with many photo sources — Google Photos, Immich, Synology Photos, Unsplash, Pexels, Telegram bot, URL proxy, and AI generation — plus date/time and weather overlays

--- a/components/board_hal/include/board_waveshare_photopainter_73.h
+++ b/components/board_hal/include/board_waveshare_photopainter_73.h
@@ -46,4 +46,16 @@
 // Display Configuration
 #define BOARD_HAL_DISPLAY_ROTATION_DEG 180
 
+// esp_pm's dynamic frequency scaling races with WiFi interrupt handling on
+// this board: a WiFi interrupt landing mid frequency-transition reliably
+// crashes with a spinlock_acquire() assertion failure (coredump confirmed:
+// esp_pm_impl_isr_hook -> leave_idle -> esp_pm_lock_acquire ->
+// spinlock_acquire, from a level-1 interrupt as the radio starts
+// generating interrupts). Disabling light_sleep_enable alone did NOT fix
+// this - the trigger is DFS's lock/ISR-hook machinery itself, not
+// specifically the light-sleep transition, since it still runs whenever
+// min_freq_mhz != max_freq_mhz. power_manager.c reads this macro to also
+// pin min_freq_mhz == max_freq_mhz, disabling DFS outright on this board.
+#define BOARD_HAL_DISABLE_AUTO_LIGHT_SLEEP 1
+
 #endif  // BOARD_WAVESHARE_PHOTOPAINTER_73_H

--- a/docs/TELEGRAM.md
+++ b/docs/TELEGRAM.md
@@ -17,16 +17,23 @@ firmware — no additional server required.
    photo (largest → smallest) until one succeeds, or asks for the image as a file instead.
 4. A caption sent with the image is drawn onto the photo as a text overlay (unless the caption
    itself is a `/`-command).
-5. `last_update_id` is persisted in NVS (+1 offset) so restarts never re-process old messages, and
+5. Every downloaded image is converted to a processed, display-ready PNG (deleting the raw
+   original) and gets a preview thumbnail, exactly like a manual Web UI upload — so it shows up
+   correctly in the gallery and is a normal, rotatable album image, not just a one-off push.
+6. `last_update_id` is persisted in NVS (+1 offset) so restarts never re-process old messages, and
    an allowlisted chat ID filters out unsolicited senders.
-6. Filenames are short and collision-safe: `img_<unix-timestamp>.<ext>`.
+7. Filenames are short and collision-safe: `img_<unix-timestamp>.<ext>`.
+8. If a poll doesn't result in a new image being displayed (nothing new arrived, or everything in
+   the batch was a command / still waiting for its pairing partner), the device falls back to
+   normal album rotation instead of leaving the previous image up indefinitely — the frame always
+   changes image on every rotation-triggering wake, same as the non-Telegram modes.
 
 **Wake-up processing order** (fixed, so behavior is predictable across timer, button, and
 Telegram-triggered wakes):
 
 ```
 WiFi connect → poll Telegram → emergency-reset scan → download & display newest image
-  → run queued "/" commands → persist last_update_id → deep sleep
+  (or fall back to album rotation) → run queued "/" commands → persist last_update_id → deep sleep
 ```
 
 ## Emergency reset
@@ -42,7 +49,21 @@ layout is landscape (or vice versa), a single portrait image would normally be l
 **Pairing** (`/pairing`) is enabled, two images of complementary orientation are combined
 side-by-side into one composed image instead. Unpaired images wait in a small persistent queue
 (NVS-backed) until a matching partner arrives; the composed result is saved to the album so
-nothing is lost.
+nothing is lost. Within a single batch of several images, only the newest ready-to-display result
+(a plain image or a freshly-composed pair) ends up on screen — everything else is still saved to
+the album and available for later rotation.
+
+The same pairing idea is also available for **normal auto-rotation** (not just Telegram receives)
+— see [Auto-rotate orientation pairing](#auto-rotate-orientation-pairing) below.
+
+## Display history (no-repeat rotation)
+
+Random album rotation (Telegram's own album included, since downloaded images become normal album
+files) tracks every image it has shown by path in a persisted history file, so it cycles through
+every image in the active album(s) once before repeating, instead of just avoiding the single
+immediately-previous pick. Once everything has been shown, the history clears itself and a new
+cycle starts automatically. `/clear_history` clears it manually (and resets the sequential-mode
+rotation cursor too).
 
 ## Commands
 
@@ -51,13 +72,18 @@ nothing is lost.
 | `/status` | Firmware, reset reason, battery, WiFi, storage %, heap %, rotation schedule, and all toggle states |
 | `/clear` | Clears the display to white |
 | `/restart` | Restarts the device |
-| `/pairing` | Toggles Hoch-/Querformat (portrait/landscape) pairing |
+| `/pairing` | Toggles portrait/landscape combining for Telegram receives |
+| `/list_albums` | Lists every album, with its active/inactive state |
+| `/active_albums` | Lists only the active albums |
+| `/enable_album <name>` | Activates an existing album for rotation |
+| `/clear_history` | Clears the display history and restarts the no-repeat cycle |
 | `/rotate_cron <M H Weekday>` | Sets the auto-rotate schedule as a cron expression |
 | `/deep_sleep on\|off` | Enables/disables deep sleep |
 | `/auto_rotate on\|off` | Enables/disables the auto-rotate timer |
 | `/wake_notify on\|off` | Toggles a status ping sent on every wake-up |
 | `/error_overlay on\|off` | Toggles an on-display warning banner after repeated WiFi failures |
 | `/wifi_perf on\|off` | Toggles the WiFi performance mode (see below) |
+| `/rotation_pairing on\|off` | Toggles auto-rotate orientation pairing (random mode only) |
 | `/help` | Lists all commands |
 | `/telegram_reset` | **Emergency**: clears the queue immediately, highest priority |
 
@@ -66,20 +92,19 @@ instead of being drawn on the image.
 
 ### `/status` and message formatting
 
-All bot replies use a consistent, scannable layout:
+All bot replies use a consistent, scannable, plain-ASCII layout:
 
 - `/status` groups related fields (firmware/reset, battery/WiFi, storage/heap, schedule,
   settings) with blank lines instead of one dense block, and reports storage and heap as both
-  absolute values and percentages (e.g. `62.3/128.0 MB frei (48%)`).
-- `/status` lists the on/off state of every toggle (`Pairing`, `Deep Sleep`, `Auto-Rotate`,
-  `Wach-Auf-Meldung`, `Fehler-Overlay`, `WLAN-Performance`) as `[x]` / `[ ]`.
-- Every reply is prefixed with `[OK]`, `[FEHLER]`, `[!]`, or `[i]` so success, failure, warning,
+  absolute values and percentages (e.g. `62.3/128.0 MB free (48%)`).
+- `/status` lists the on/off state of every toggle as `[x]` / `[ ]`.
+- Every reply is prefixed with `[OK]`, `[ERROR]`, `[!]`, or `[i]` so success, failure, warning,
   and usage-hint messages are visually distinct at a glance.
-- `/help` is grouped into **Status / Anzeige / Einstellungen / Notfall** sections.
+- `/help` is grouped into Status / Display / Albums / Settings / Emergency sections.
 
-Text stays plain ASCII (no Markdown parse mode, no umlauts/emoji) by design — Telegram's
-`parse_mode` would require escaping user-controlled text like SSIDs and cron expressions to avoid
-silently failing to send.
+Text stays plain ASCII (no Markdown parse mode, no accented characters/emoji) by design —
+Telegram's `parse_mode` would require escaping user-controlled text like SSIDs and cron
+expressions to avoid silently failing to send.
 
 ## Low battery & wake notifications
 
@@ -95,7 +120,7 @@ All default to preserving existing behavior for users who don't configure Telegr
 | Setting | Default | Purpose |
 |---|---|---|
 | Telegram bot token / chat ID | empty | Enables the Telegram rotation mode when both are set |
-| Pairing | on | Combine mismatched-orientation images instead of letterboxing |
+| Pairing | on | Combine mismatched-orientation Telegram receives instead of letterboxing |
 | Deep Sleep | on | Existing setting, now also controllable via `/deep_sleep` |
 | Auto-Rotate | on | Existing setting, now also controllable via `/auto_rotate` |
 | Wake notify | off | Status ping to Telegram on every wake |
@@ -103,7 +128,8 @@ All default to preserving existing behavior for users who don't configure Telegr
 | WiFi performance mode | off | See below |
 | Home Assistant integration | **off** | Master switch for all HA features (see below) |
 | OTA auto-check | on | Automatic update check on cold boot |
-| Thumbnail gallery (Web UI) | **off** | Client-side only; large galleries slow down the device's HTTP server |
+| Auto-rotate orientation pairing | **off** | See [below](#auto-rotate-orientation-pairing) - random mode only |
+| Thumbnail gallery (Web UI) | **off** | Client-side toggle; large galleries slow down the device's HTTP server |
 
 ### WiFi performance mode
 
@@ -124,6 +150,26 @@ their integration working — the flag isn't silently sprung on existing users.
 Disabling automatic OTA checks (`ota_check_enabled = false`) skips the cold-boot update check
 entirely — useful for dev builds where a `dev-<commit>` version string otherwise causes spurious
 "update available" comparisons.
+
+### Auto-rotate orientation pairing
+
+Extends the same portrait/landscape combining idea to **normal auto-rotation**, not just Telegram
+receives. When enabled and the randomly-picked next image doesn't match the panel's orientation,
+the device immediately looks for another mismatched image in the active album(s) and combines
+them instead of showing one letterboxed. The combined result is saved permanently in the album
+(with a thumbnail); both source images are kept too, still independently rotatable later.
+
+**Random rotation mode only** — sequential mode's deterministic image-order cursor is deliberately
+left untouched, so this setting has no effect there. The Web UI shows a warning if the toggle is
+on while Sequential mode is selected.
+
+### Error overlay test
+
+Settings includes a "Test Error Overlay" button that triggers the overlay immediately
+(`POST /api/error-overlay/test`), regardless of the setting above, to preview it without waiting
+for 3 consecutive WiFi failures. If there's no current image to overlay onto (fresh boot, or after
+`/clear`), it generates a blank canvas instead of failing, so the preview - and the real
+WiFi-failure case on a device that's never displayed anything yet - always has something to show.
 
 ## Security
 

--- a/docs/TELEGRAM.md
+++ b/docs/TELEGRAM.md
@@ -1,0 +1,145 @@
+# Telegram Bot Integration
+
+A rotation mode that receives images directly via the [Telegram Bot API](https://core.telegram.org/bots/api),
+independent of the existing SD-card and URL-fetch rotation modes. Unlike the companion
+[esp32-photoframe-server](https://github.com/aitjcize/esp32-photoframe-server)'s Telegram source
+(which relays through a separate server), this integration talks to Telegram directly from the
+firmware — no additional server required.
+
+## How it works
+
+1. On every deep-sleep wake (or auto-rotate timer), the device long-polls Telegram's `getUpdates`
+   endpoint for new messages.
+2. Images sent as a **photo** or as a **file/document** are accepted, in any format the firmware
+   already supports.
+3. Telegram re-encodes compressed photos as **progressive JPEG**, which the firmware's decoder
+   cannot read. The bot automatically falls back through Telegram's other resolutions of the same
+   photo (largest → smallest) until one succeeds, or asks for the image as a file instead.
+4. A caption sent with the image is drawn onto the photo as a text overlay (unless the caption
+   itself is a `/`-command).
+5. `last_update_id` is persisted in NVS (+1 offset) so restarts never re-process old messages, and
+   an allowlisted chat ID filters out unsolicited senders.
+6. Filenames are short and collision-safe: `img_<unix-timestamp>.<ext>`.
+
+**Wake-up processing order** (fixed, so behavior is predictable across timer, button, and
+Telegram-triggered wakes):
+
+```
+WiFi connect → poll Telegram → emergency-reset scan → download & display newest image
+  → run queued "/" commands → persist last_update_id → deep sleep
+```
+
+## Emergency reset
+
+`/telegram_reset` is checked **before** anything else in the queue. It immediately clears the
+whole pending-image and pending-command queue and puts the device back to sleep, bypassing normal
+processing — a safety valve if the queue gets flooded or stuck.
+
+## Multi-image orientation pairing
+
+If the display is in portrait orientation (from `display_rotation_deg`) but the frame's default
+layout is landscape (or vice versa), a single portrait image would normally be letterboxed. When
+**Pairing** (`/pairing`) is enabled, two images of complementary orientation are combined
+side-by-side into one composed image instead. Unpaired images wait in a small persistent queue
+(NVS-backed) until a matching partner arrives; the composed result is saved to the album so
+nothing is lost.
+
+## Commands
+
+| Command | Effect |
+|---|---|
+| `/status` | Firmware, reset reason, battery, WiFi, storage %, heap %, rotation schedule, and all toggle states |
+| `/clear` | Clears the display to white |
+| `/restart` | Restarts the device |
+| `/pairing` | Toggles Hoch-/Querformat (portrait/landscape) pairing |
+| `/rotate_cron <M H Weekday>` | Sets the auto-rotate schedule as a cron expression |
+| `/deep_sleep on\|off` | Enables/disables deep sleep |
+| `/auto_rotate on\|off` | Enables/disables the auto-rotate timer |
+| `/wake_notify on\|off` | Toggles a status ping sent on every wake-up |
+| `/error_overlay on\|off` | Toggles an on-display warning banner after repeated WiFi failures |
+| `/wifi_perf on\|off` | Toggles the WiFi performance mode (see below) |
+| `/help` | Lists all commands |
+| `/telegram_reset` | **Emergency**: clears the queue immediately, highest priority |
+
+Images can also be sent with a caption starting with `/` — the caption is treated as a command
+instead of being drawn on the image.
+
+### `/status` and message formatting
+
+All bot replies use a consistent, scannable layout:
+
+- `/status` groups related fields (firmware/reset, battery/WiFi, storage/heap, schedule,
+  settings) with blank lines instead of one dense block, and reports storage and heap as both
+  absolute values and percentages (e.g. `62.3/128.0 MB frei (48%)`).
+- `/status` lists the on/off state of every toggle (`Pairing`, `Deep Sleep`, `Auto-Rotate`,
+  `Wach-Auf-Meldung`, `Fehler-Overlay`, `WLAN-Performance`) as `[x]` / `[ ]`.
+- Every reply is prefixed with `[OK]`, `[FEHLER]`, `[!]`, or `[i]` so success, failure, warning,
+  and usage-hint messages are visually distinct at a glance.
+- `/help` is grouped into **Status / Anzeige / Einstellungen / Notfall** sections.
+
+Text stays plain ASCII (no Markdown parse mode, no umlauts/emoji) by design — Telegram's
+`parse_mode` would require escaping user-controlled text like SSIDs and cron expressions to avoid
+silently failing to send.
+
+## Low battery & wake notifications
+
+- If the battery drops below 20%, a one-time warning is sent via Telegram even if there were no
+  new messages to process (debounced — fires once per discharge cycle, clears again above 25%).
+- Optional wake-up ping (`/wake_notify`): sends a full `/status`-style report to Telegram on every
+  wake, so you can confirm the device is alive without opening the web UI.
+
+## Settings (Web UI + Telegram)
+
+All default to preserving existing behavior for users who don't configure Telegram at all.
+
+| Setting | Default | Purpose |
+|---|---|---|
+| Telegram bot token / chat ID | empty | Enables the Telegram rotation mode when both are set |
+| Pairing | on | Combine mismatched-orientation images instead of letterboxing |
+| Deep Sleep | on | Existing setting, now also controllable via `/deep_sleep` |
+| Auto-Rotate | on | Existing setting, now also controllable via `/auto_rotate` |
+| Wake notify | off | Status ping to Telegram on every wake |
+| Error overlay | off | On-display warning banner after persistent WiFi failures |
+| WiFi performance mode | off | See below |
+| Home Assistant integration | **off** | Master switch for all HA features (see below) |
+| OTA auto-check | on | Automatic update check on cold boot |
+| Thumbnail gallery (Web UI) | **off** | Client-side only; large galleries slow down the device's HTTP server |
+
+### WiFi performance mode
+
+WiFi power-save is normally tiered: the radio only stays in full-receive mode while someone is
+actively looking at the web UI, and drops to a power-saving mode otherwise. Enabling this toggle
+forces full performance at all times, trading battery life for a consistently faster web UI —
+useful for always-on / Home Assistant setups.
+
+### Home Assistant master switch
+
+All Home Assistant integration code checks a single `ha_enabled` flag before doing anything
+(`ha_is_configured()` requires both the existing HA URL config **and** this flag). It defaults to
+**off**, but for anyone who already had HA configured before this change, the migration path keeps
+their integration working — the flag isn't silently sprung on existing users.
+
+### OTA auto-check toggle
+
+Disabling automatic OTA checks (`ota_check_enabled = false`) skips the cold-boot update check
+entirely — useful for dev builds where a `dev-<commit>` version string otherwise causes spurious
+"update available" comparisons.
+
+## Security
+
+- **Redacted logging**: the bot token is never logged. All Telegram HTTP calls log through
+  `redact_url_for_log()`, which strips the token before anything reaches the log.
+- **Chat allowlist**: only messages from the configured chat ID are ever processed.
+- Keep your bot token private — anyone with it can send commands to your device, including
+  `/telegram_reset` and `/restart`.
+
+## Setup
+
+1. Talk to [@BotFather](https://t.me/BotFather) on Telegram, create a bot, and copy the token it
+   gives you.
+2. Message your new bot once (or add it to a group) so you have a chat ID; the simplest way to
+   find it is to send a message and check `https://api.telegram.org/bot<TOKEN>/getUpdates`.
+3. In the PhotoFrame web UI, go to **Settings → Telegram**, enter the bot token and chat ID, and
+   enable the integration.
+4. Send the bot a photo. It will be processed on the next wake (or trigger one immediately,
+   depending on your rotation-timer settings).

--- a/docs/TELEGRAM.md
+++ b/docs/TELEGRAM.md
@@ -17,9 +17,11 @@ firmware — no additional server required.
    photo (largest → smallest) until one succeeds, or asks for the image as a file instead.
 4. A caption sent with the image is drawn onto the photo as a text overlay (unless the caption
    itself is a `/`-command).
-5. Every downloaded image is converted to a processed, display-ready PNG (deleting the raw
-   original) and gets a preview thumbnail, exactly like a manual Web UI upload — so it shows up
-   correctly in the gallery and is a normal, rotatable album image, not just a one-off push.
+5. A preview thumbnail is generated from the raw download first (true colors, not the e-paper
+   palette), then the image is converted to a processed, display-ready PNG (deleting the raw
+   original by default), exactly like a manual Web UI upload — so it shows up correctly in the
+   gallery and is a normal, rotatable album image, not just a one-off push. Optionally, the raw
+   original can be kept instead of deleted (`/keep_originals`, see below).
 6. `last_update_id` is persisted in NVS (+1 offset) so restarts never re-process old messages, and
    an allowlisted chat ID filters out unsolicited senders.
 7. Filenames are short and collision-safe: `img_<unix-timestamp>.<ext>`.
@@ -85,6 +87,7 @@ rotation cursor too).
 | `/wifi_perf on\|off` | Toggles the WiFi performance mode (see below) |
 | `/rotation_pairing on\|off` | Toggles auto-rotate orientation pairing (random mode only) |
 | `/rotation_notify on\|off` | Sends a thumbnail when a wake displays an image via fallback rotation |
+| `/keep_originals on\|off` | Keeps a copy of each photo as received, before e-paper processing |
 | `/help` | Lists all commands |
 | `/telegram_reset` | **Emergency**: clears the queue immediately, highest priority |
 
@@ -183,6 +186,19 @@ sends a thumbnail of whatever got displayed instead - so the chat still shows wh
 the frame even when nothing was pushed to it. Only fires when the display actually changed (not
 when rotation was a no-op, e.g. no enabled albums). Off by default; toggle via Web UI or
 `/rotation_notify on|off`.
+
+### Keep originals
+
+Each incoming Telegram photo is normally converted straight to a display-ready PNG and the raw
+download is deleted. When enabled, a copy of the raw file is instead kept under `Telegram/Originals`
+on the SD card — a plain archive path, not an album, so it's invisible to the gallery and rotation.
+Off by default; toggle via Web UI or `/keep_originals on|off`.
+
+For "photo" messages (not files sent as a document), the archived copy is always re-fetched at
+Telegram's largest available size for that photo — even if the size actually used for the display
+conversion above had to fall back to a smaller one because the largest turned out to be a
+progressive JPEG the firmware's decoder can't read. Decoding isn't required to archive raw bytes, so
+the best quality available is kept regardless of that display-side limitation.
 
 ### Error overlay test
 

--- a/docs/TELEGRAM.md
+++ b/docs/TELEGRAM.md
@@ -84,6 +84,7 @@ rotation cursor too).
 | `/error_overlay on\|off` | Toggles an on-display warning banner after repeated WiFi failures |
 | `/wifi_perf on\|off` | Toggles the WiFi performance mode (see below) |
 | `/rotation_pairing on\|off` | Toggles auto-rotate orientation pairing (random mode only) |
+| `/rotation_notify on\|off` | Sends a thumbnail when a wake displays an image via fallback rotation |
 | `/help` | Lists all commands |
 | `/telegram_reset` | **Emergency**: clears the queue immediately, highest priority |
 
@@ -113,6 +114,17 @@ expressions to avoid silently failing to send.
 - Optional wake-up ping (`/wake_notify`): sends a full `/status`-style report to Telegram on every
   wake, so you can confirm the device is alive without opening the web UI.
 
+## Battery history
+
+A "Battery History" tab in the Web UI plots battery percentage over time (a plain SVG chart, no
+external charting library), marking charging/USB periods separately from on-battery readings. One
+reading is recorded after every displayed image, to a small persisted log
+(`/storage/.battery_history`) that resets automatically once the battery reaches 95% (a fresh full
+charge) or after 180 days, whichever comes first.
+
+An estimate of days remaining until 20% - based on the drain rate observed since the last charge -
+is shown next to the Web UI chart, in `/status`, and in the optional wake-up notification.
+
 ## Settings (Web UI + Telegram)
 
 All default to preserving existing behavior for users who don't configure Telegram at all.
@@ -129,6 +141,7 @@ All default to preserving existing behavior for users who don't configure Telegr
 | Home Assistant integration | **off** | Master switch for all HA features (see below) |
 | OTA auto-check | on | Automatic update check on cold boot |
 | Auto-rotate orientation pairing | **off** | See [below](#auto-rotate-orientation-pairing) - random mode only |
+| Fallback-rotation notification | **off** | See [below](#fallback-rotation-notification) |
 | Thumbnail gallery (Web UI) | **off** | Client-side toggle; large galleries slow down the device's HTTP server |
 
 ### WiFi performance mode
@@ -162,6 +175,14 @@ them instead of showing one letterboxed. The combined result is saved permanentl
 **Random rotation mode only** — sequential mode's deterministic image-order cursor is deliberately
 left untouched, so this setting has no effect there. The Web UI shows a warning if the toggle is
 on while Sequential mode is selected.
+
+### Fallback-rotation notification
+
+When a wake falls back to normal album rotation (no new Telegram image that cycle), optionally
+sends a thumbnail of whatever got displayed instead - so the chat still shows what's currently on
+the frame even when nothing was pushed to it. Only fires when the display actually changed (not
+when rotation was a no-op, e.g. no enabled albums). Off by default; toggle via Web UI or
+`/rotation_notify on|off`.
 
 ### Error overlay test
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SOURCES
     "splash_screen.c"
     "storage.c"
     "cron.c"
+    "telegram_bot.c"
     "utils.c"
     "wifi_manager.c"
     "wifi_provisioning.c"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     "display_manager.c"
     "dns_server.c"
     "ha_integration.c"
+    "history_manager.c"
     "http_server.c"
     "image_processor.c"
     "main.c"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     "album_manager.c"
+    "battery_history.c"
     "cert_pin.c"
     "color_palette.c"
     "config_manager.c"

--- a/main/battery_history.c
+++ b/main/battery_history.c
@@ -1,0 +1,192 @@
+#include "battery_history.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "board_hal.h"
+#include "config.h"
+#include "esp_log.h"
+#include "storage.h"
+
+static const char *TAG = "battery_history";
+
+// Same "-1 means unknown, never a real low reading" guard as
+// telegram_bot.c's get_valid_battery_percent() - kept as a local duplicate
+// (small, and this module has no other reason to depend on telegram_bot.c).
+static bool get_valid_battery_reading(int *out_percent, bool *out_charging)
+{
+    if (!board_hal_is_battery_connected()) {
+        return false;
+    }
+    int percent = board_hal_get_battery_percent();
+    if (percent < 0) {
+        return false;
+    }
+    *out_percent = percent;
+    *out_charging = board_hal_is_charging() || board_hal_is_usb_connected();
+    return true;
+}
+
+// Peeks the timestamp of the first (oldest) line in the history file.
+static bool peek_oldest_timestamp(time_t *out_ts)
+{
+    FILE *f = fopen(BATTERY_HISTORY_PATH, "r");
+    if (!f) {
+        return false;
+    }
+    char line[64];
+    bool found = false;
+    if (fgets(line, sizeof(line), f)) {
+        long long ts = 0;
+        if (sscanf(line, "%lld,", &ts) == 1) {
+            *out_ts = (time_t) ts;
+            found = true;
+        }
+    }
+    fclose(f);
+    return found;
+}
+
+void battery_history_record(void)
+{
+    int percent;
+    bool charging;
+    if (!get_valid_battery_reading(&percent, &charging)) {
+        return;  // No battery installed - nothing meaningful to log.
+    }
+    if (!storage_has_persistent_storage()) {
+        return;  // No persistent storage - can't keep a history file.
+    }
+
+    // Reset conditions: fresh full charge starts a new discharge cycle, or
+    // the log has simply gotten too old (e.g. permanently on USB, never
+    // reaching the reset-percent trigger).
+    bool should_reset = (percent >= BATTERY_HISTORY_RESET_PERCENT);
+    const char *reset_reason = "fresh charge";
+    if (!should_reset) {
+        time_t oldest;
+        if (peek_oldest_timestamp(&oldest)) {
+            double age_days = difftime(time(NULL), oldest) / 86400.0;
+            if (age_days > BATTERY_HISTORY_MAX_AGE_DAYS) {
+                should_reset = true;
+                reset_reason = "log too old";
+            }
+        }
+    }
+    if (should_reset) {
+        remove(BATTERY_HISTORY_PATH);
+        ESP_LOGI(TAG, "Battery history reset (%s)", reset_reason);
+    }
+
+    FILE *f = fopen(BATTERY_HISTORY_PATH, "a");
+    if (!f) {
+        ESP_LOGW(TAG, "Failed to open battery history for append");
+        return;
+    }
+    fprintf(f, "%lld,%d,%d\n", (long long) time(NULL), percent, charging ? 1 : 0);
+    fclose(f);
+}
+
+cJSON *battery_history_build_json(void)
+{
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        return NULL;
+    }
+    cJSON *entries = cJSON_AddArrayToObject(root, "entries");
+    if (!entries) {
+        cJSON_Delete(root);
+        return NULL;
+    }
+
+    if (storage_has_persistent_storage()) {
+        FILE *f = fopen(BATTERY_HISTORY_PATH, "r");
+        if (f) {
+            char line[64];
+            while (fgets(line, sizeof(line), f)) {
+                long long ts = 0;
+                int percent = 0, charging = 0;
+                if (sscanf(line, "%lld,%d,%d", &ts, &percent, &charging) == 3) {
+                    cJSON *e = cJSON_CreateObject();
+                    if (e) {
+                        cJSON_AddNumberToObject(e, "t", (double) ts);
+                        cJSON_AddNumberToObject(e, "p", percent);
+                        cJSON_AddBoolToObject(e, "c", charging != 0);
+                        cJSON_AddItemToArray(entries, e);
+                    }
+                }
+            }
+            fclose(f);
+        }
+    }
+
+    double days;
+    if (battery_history_estimate_days_remaining(&days)) {
+        cJSON_AddNumberToObject(root, "days_remaining", days);
+    } else {
+        cJSON_AddNullToObject(root, "days_remaining");
+    }
+
+    return root;
+}
+
+bool battery_history_estimate_days_remaining(double *out_days)
+{
+    if (!storage_has_persistent_storage()) {
+        return false;
+    }
+    FILE *f = fopen(BATTERY_HISTORY_PATH, "r");
+    if (!f) {
+        return false;
+    }
+
+    // Find the most recent battery-only (non-charging) run: any charging
+    // entry breaks the run, and the next battery-only entry starts a fresh
+    // one. Using only the final run keeps the estimate representative of
+    // current behavior rather than being skewed by older, possibly
+    // different usage patterns earlier in the log.
+    time_t run_start_ts = 0, run_end_ts = 0;
+    int run_start_pct = -1, run_end_pct = -1;
+    bool in_run = false;
+
+    char line[64];
+    while (fgets(line, sizeof(line), f)) {
+        long long ts = 0;
+        int percent = 0, charging = 0;
+        if (sscanf(line, "%lld,%d,%d", &ts, &percent, &charging) != 3) {
+            continue;
+        }
+        if (charging) {
+            in_run = false;
+            continue;
+        }
+        if (!in_run) {
+            run_start_ts = (time_t) ts;
+            run_start_pct = percent;
+            in_run = true;
+        }
+        run_end_ts = (time_t) ts;
+        run_end_pct = percent;
+    }
+    fclose(f);
+
+    if (!in_run || run_start_pct < 0 || run_end_pct < 0 || run_end_ts <= run_start_ts) {
+        return false;  // Not enough battery-only history yet.
+    }
+
+    double elapsed_days = difftime(run_end_ts, run_start_ts) / 86400.0;
+    double drop = (double) (run_start_pct - run_end_pct);
+    if (elapsed_days <= 0 || drop <= 0) {
+        return false;  // No measurable drain yet (e.g. only one reading so far).
+    }
+
+    double percent_per_day = drop / elapsed_days;
+    if (run_end_pct <= BATTERY_HISTORY_TARGET_PERCENT) {
+        *out_days = 0;
+        return true;
+    }
+    *out_days = (run_end_pct - BATTERY_HISTORY_TARGET_PERCENT) / percent_per_day;
+    return true;
+}

--- a/main/battery_history.h
+++ b/main/battery_history.h
@@ -1,0 +1,33 @@
+#ifndef BATTERY_HISTORY_H
+#define BATTERY_HISTORY_H
+
+#include <stdbool.h>
+
+#include "cJSON.h"
+
+// Records the current battery reading to the persisted history log. No-op
+// if no battery is present (e.g. pure USB power with no battery installed)
+// or no persistent storage is mounted. Call once per successfully displayed
+// image (see the history_manager_mark_shown() call site in
+// display_manager.c's display_manager_show_image()).
+//
+// Automatically clears the whole history and starts a fresh log when the
+// battery is freshly charged (>= BATTERY_HISTORY_RESET_PERCENT) or the
+// oldest entry is more than BATTERY_HISTORY_MAX_AGE_DAYS old - see config.h.
+void battery_history_record(void);
+
+// Builds the JSON payload for the Web UI battery-history tab:
+// {"entries": [{"t": <unix_ts>, "p": <0-100>, "c": <bool charging>}, ...],
+//  "days_remaining": <number or null>}
+// Caller owns the returned object (cJSON_Delete when done). Returns NULL on
+// allocation failure.
+cJSON *battery_history_build_json(void);
+
+// Estimates days remaining until the battery reaches
+// BATTERY_HISTORY_TARGET_PERCENT, based on the drain rate observed over the
+// most recent battery-only (non-charging) run in the log. Returns false if
+// there isn't enough such history yet to estimate (fresh log, no
+// measurable drain, or currently charging with no prior battery-only data).
+bool battery_history_estimate_days_remaining(double *out_days);
+
+#endif

--- a/main/config.h
+++ b/main/config.h
@@ -6,7 +6,11 @@
 // Uncomment to debug deep sleep wake
 // #define DEBUG_DEEP_SLEEP_WAKE
 
-typedef enum { ROTATION_MODE_STORAGE = 0, ROTATION_MODE_URL = 1 } rotation_mode_t;
+typedef enum {
+    ROTATION_MODE_STORAGE = 0,
+    ROTATION_MODE_URL = 1,
+    ROTATION_MODE_TELEGRAM = 2
+} rotation_mode_t;
 
 typedef enum { SD_ROTATION_RANDOM = 0, SD_ROTATION_SEQUENTIAL = 1 } sd_rotation_mode_t;
 
@@ -34,12 +38,16 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 #define HTTP_HEADER_VALUE_MAX_LEN 512
 #define CA_CERT_MAX_LEN 4096
 #define HTTP_ETAG_MAX_LEN 128
+#define TELEGRAM_BOT_TOKEN_MAX_LEN 128
+#define TELEGRAM_CHAT_ID_MAX_LEN 32
 
 #define DEFAULT_DEVICE_NAME "PhotoFrame"
 #define DEFAULT_WIFI_SSID "PhotoFrame"
 #define DEFAULT_WIFI_PASSWORD "photoframe123"
 #define DEFAULT_IMAGE_URL "https://loremflickr.com/800/480"
 #define DEFAULT_HA_URL ""
+#define DEFAULT_TELEGRAM_BOT_TOKEN ""
+#define DEFAULT_TELEGRAM_CHAT_ID ""
 #define DEFAULT_TIMEZONE "UTC0"
 #define DEFAULT_NTP_SERVER "pool.ntp.org"
 
@@ -51,6 +59,7 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 
 #define IMAGE_DIRECTORY FS_MOUNT_POINT "/images"
 #define DOWNLOAD_DIRECTORY IMAGE_DIRECTORY "/Downloads"
+#define TELEGRAM_DOWNLOAD_DIRECTORY IMAGE_DIRECTORY "/Telegram"
 
 #define CURRENT_UPLOAD_PATH FS_MOUNT_POINT "/.current.tmp"
 #define CURRENT_JPG_PATH FS_MOUNT_POINT "/.current.jpg"
@@ -150,6 +159,45 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 // Home Assistant
 #define NVS_HA_URL_KEY "ha_url"
 
+// Telegram Bot
+#define NVS_TELEGRAM_BOT_TOKEN_KEY "tg_bot_token"
+#define NVS_TELEGRAM_CHAT_ID_KEY "tg_chat_id"
+#define NVS_TELEGRAM_LAST_UPDATE_ID_KEY "tg_last_upd_id"
+// Orientation-pairing: combine two mismatched-orientation Telegram photos
+// (e.g. two portrait shots on a landscape frame) into one image instead of
+// ever showing one alone. Every mismatched image that arrives is queued here
+// (not just one) so nothing is lost if several arrive before a partner shows
+// up; persisted across deep sleep (RAM/files don't survive on MemFS-only
+// boards, NVS does).
+#define NVS_TELEGRAM_PAIRING_KEY "tg_pairing"
+#define NVS_TELEGRAM_PENDING_LIST_KEY "tg_pend_list"
+#define TELEGRAM_MAX_PENDING_IMAGES 6
+#define NVS_TELEGRAM_LOW_BATT_WARNED_KEY "tg_low_batt"
+// Wake-up status ping (SSID/IP/battery/wake reason/rotation schedule) sent to
+// Telegram every poll, even with no new updates - opt-in, off by default.
+#define NVS_TELEGRAM_WAKE_NOTIFY_KEY "tg_wake_notify"
+
+// Home Assistant
+#define NVS_HA_ENABLED_KEY "ha_enabled"
+
+// On-display error overlay for persistent failures (e.g. repeated WiFi
+// connect failure on a scheduled wake) - opt-in, off by default.
+#define NVS_ERROR_OVERLAY_ENABLED_KEY "err_overlay_en"
+#define NVS_WIFI_FAIL_COUNT_KEY "wifi_fail_cnt"
+#define WIFI_FAIL_OVERLAY_THRESHOLD 3
+
+// WiFi performance mode: when enabled (default), the existing tiered policy
+// (power_manager's sleep_timer_task) grants full-RX/low-latency WiFi during
+// interactive wakes or USB power. When disabled, WiFi power-save always stays
+// on regardless of that policy, trading web UI responsiveness for lower draw.
+#define NVS_WIFI_PERF_MODE_ENABLED_KEY "wifi_perf_mode"
+
+// On battery, WiFi association draws a brief high-current TX burst; capping
+// TX power lowers that peak (at some cost to range). Value is in units of
+// 0.25 dBm (esp_wifi_set_max_tx_power() convention) - 60 = 15 dBm, versus the
+// factory default of up to ~20 dBm (80).
+#define WIFI_BATTERY_MAX_TX_POWER_QUARTER_DBM 60
+
 // AI API Keys (for webapp client use)
 #define AI_API_KEY_MAX_LEN 256
 #define NVS_OPENAI_API_KEY_KEY "openai_key"
@@ -158,5 +206,21 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 // OTA Configuration
 #define GITHUB_API_URL "https://api.github.com/repos/aitjcize/esp32-photoframe/releases/latest"
 #define OTA_CHECK_INTERVAL_MS (24 * 60 * 60 * 1000)  // 24 hours
+#define NVS_OTA_CHECK_ENABLED_KEY "ota_check_en"
+
+// Telegram Bot API
+// Note: the real Telegram Bot API base is "https://api.telegram.org/bot<TOKEN>/<METHOD>"
+// (not "https://telegram.org<TOKEN>/..."). TELEGRAM_API_HOST + TELEGRAM_API_BASE_FMT
+// build that URL at runtime once the token is known.
+#define TELEGRAM_API_HOST "api.telegram.org"
+#define TELEGRAM_API_BASE_FMT "https://api.telegram.org/bot%s/%s"
+#define TELEGRAM_POLL_TIMEOUT_SEC 10    // long-poll timeout passed to getUpdates
+#define TELEGRAM_HTTP_TIMEOUT_MS 15000  // per-request HTTP timeout
+#define TELEGRAM_MAX_UPDATES_PER_POLL 50
+#define TELEGRAM_RESET_COMMAND "/telegram_reset"
+#define TELEGRAM_MAX_PENDING_COMMANDS 8
+#define TELEGRAM_COMMAND_MAX_LEN 128
+#define TELEGRAM_CAPTION_MAX_LEN 128
+#define TELEGRAM_FILE_ID_MAX_LEN 128
 
 #endif

--- a/main/config.h
+++ b/main/config.h
@@ -63,6 +63,12 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 #define IMAGE_DIRECTORY FS_MOUNT_POINT "/images"
 #define DOWNLOAD_DIRECTORY IMAGE_DIRECTORY "/Downloads"
 #define TELEGRAM_DOWNLOAD_DIRECTORY IMAGE_DIRECTORY "/Telegram"
+// Optional archive of Telegram photos exactly as received, before e-paper
+// processing (dithering/palette quantization) overwrites them. Not a
+// subdirectory album manager/rotation ever look inside (they only enumerate
+// top-level album dirs and DT_REG files directly within them), so it never
+// shows up in the gallery or rotation. Opt-in, off by default.
+#define TELEGRAM_ORIGINALS_DIRECTORY TELEGRAM_DOWNLOAD_DIRECTORY "/Originals"
 
 #define CURRENT_UPLOAD_PATH FS_MOUNT_POINT "/.current.tmp"
 #define CURRENT_JPG_PATH FS_MOUNT_POINT "/.current.jpg"
@@ -70,11 +76,6 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 #define CURRENT_PNG_PATH FS_MOUNT_POINT "/.current.png"
 #define CURRENT_EPD_PATH FS_MOUNT_POINT "/.current.epdgz"
 #define CURRENT_IMAGE_LINK FS_MOUNT_POINT "/.current.lnk"
-// Scratch full-size PNG used only while generating a Telegram-image
-// thumbnail sidecar - kept separate from CURRENT_PNG_PATH so thumbnail
-// generation for a non-displayed image in a batch can never collide with
-// whichever image ends up actually being shown that same poll cycle.
-#define TELEGRAM_THUMB_SCRATCH_PATH FS_MOUNT_POINT "/.tg_thumb_scratch.png"
 #define TELEGRAM_THUMBNAIL_MAX_DIMENSION 300
 #define CURRENT_CALIBRATION_PATH FS_MOUNT_POINT "/.calibration.png"
 
@@ -227,6 +228,10 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 // the chat, so it stays visible what the frame is showing even without a
 // push. Opt-in, off by default.
 #define NVS_TELEGRAM_ROTATION_NOTIFY_KEY "tg_rot_notify"
+
+// Keep a copy of each Telegram photo exactly as received (pre-processing) in
+// TELEGRAM_ORIGINALS_DIRECTORY. Opt-in, off by default.
+#define NVS_TELEGRAM_KEEP_ORIGINALS_KEY "tg_keep_orig"
 
 // On battery, WiFi association draws a brief high-current TX burst; capping
 // TX power lowers that peak (at some cost to range). Value is in units of

--- a/main/config.h
+++ b/main/config.h
@@ -67,7 +67,18 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 #define CURRENT_PNG_PATH FS_MOUNT_POINT "/.current.png"
 #define CURRENT_EPD_PATH FS_MOUNT_POINT "/.current.epdgz"
 #define CURRENT_IMAGE_LINK FS_MOUNT_POINT "/.current.lnk"
+// Scratch full-size PNG used only while generating a Telegram-image
+// thumbnail sidecar - kept separate from CURRENT_PNG_PATH so thumbnail
+// generation for a non-displayed image in a batch can never collide with
+// whichever image ends up actually being shown that same poll cycle.
+#define TELEGRAM_THUMB_SCRATCH_PATH FS_MOUNT_POINT "/.tg_thumb_scratch.png"
+#define TELEGRAM_THUMBNAIL_MAX_DIMENSION 300
 #define CURRENT_CALIBRATION_PATH FS_MOUNT_POINT "/.calibration.png"
+
+// Display-history file (one shown image's full path per line) - lets random
+// rotation and the Telegram fallback rotation cycle through every image once
+// before repeating. See history_manager.[ch].
+#define DISPLAY_HISTORY_PATH FS_MOUNT_POINT "/.display_history"
 
 #ifdef DEBUG_DEEP_SLEEP_WAKE
 #define AUTO_SLEEP_TIMEOUT_SEC 60
@@ -191,6 +202,13 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 // interactive wakes or USB power. When disabled, WiFi power-save always stays
 // on regardless of that policy, trading web UI responsiveness for lower draw.
 #define NVS_WIFI_PERF_MODE_ENABLED_KEY "wifi_perf_mode"
+
+// Orientation-pairing during normal (non-Telegram) auto-rotation: when the
+// randomly-picked next image doesn't match the panel's orientation, look for
+// another mismatched image in the active album(s) and combine them instead
+// of showing one letterboxed. Opt-in, off by default. Random rotation mode
+// only - sequential mode's deterministic index cursor is left untouched.
+#define NVS_ROTATION_PAIRING_ENABLED_KEY "rot_pairing_en"
 
 // On battery, WiFi association draws a brief high-current TX burst; capping
 // TX power lowers that peak (at some cost to range). Value is in units of

--- a/main/config.h
+++ b/main/config.h
@@ -80,6 +80,15 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 // before repeating. See history_manager.[ch].
 #define DISPLAY_HISTORY_PATH FS_MOUNT_POINT "/.display_history"
 
+// Battery history log (one "<unix_ts>,<percent>,<charging 0|1>" line per
+// recorded reading, appended once per successfully displayed image). See
+// battery_history.[ch]. Cleared automatically on a fresh full charge or
+// after BATTERY_HISTORY_MAX_AGE_DAYS, whichever comes first.
+#define BATTERY_HISTORY_PATH FS_MOUNT_POINT "/.battery_history"
+#define BATTERY_HISTORY_RESET_PERCENT 95
+#define BATTERY_HISTORY_MAX_AGE_DAYS 180
+#define BATTERY_HISTORY_TARGET_PERCENT 20
+
 #ifdef DEBUG_DEEP_SLEEP_WAKE
 #define AUTO_SLEEP_TIMEOUT_SEC 60
 #else
@@ -209,6 +218,12 @@ typedef enum { IP_MODE_DHCP = 0, IP_MODE_STATIC = 1 } ip_mode_t;
 // of showing one letterboxed. Opt-in, off by default. Random rotation mode
 // only - sequential mode's deterministic index cursor is left untouched.
 #define NVS_ROTATION_PAIRING_ENABLED_KEY "rot_pairing_en"
+
+// When a Telegram-mode wake falls back to normal album rotation (no new
+// Telegram image this cycle), send a thumbnail of whatever got displayed to
+// the chat, so it stays visible what the frame is showing even without a
+// push. Opt-in, off by default.
+#define NVS_TELEGRAM_ROTATION_NOTIFY_KEY "tg_rot_notify"
 
 // On battery, WiFi association draws a brief high-current TX burst; capping
 // TX power lowers that peak (at some cost to range). Value is in units of

--- a/main/config_manager.c
+++ b/main/config_manager.c
@@ -54,6 +54,34 @@ static char image_etag[HTTP_ETAG_MAX_LEN] = {0};
 // Home Assistant
 static char ha_url[HA_URL_MAX_LEN] = {0};
 
+// Telegram Bot
+static char telegram_bot_token[TELEGRAM_BOT_TOKEN_MAX_LEN] = {0};
+static char telegram_chat_id[TELEGRAM_CHAT_ID_MAX_LEN] = {0};
+static int64_t telegram_last_update_id = 0;
+static bool telegram_pairing_enabled = true;
+static bool telegram_low_battery_warned = false;
+static bool telegram_wake_notify_enabled = false;
+
+typedef struct {
+    char path[320];
+    char caption[TELEGRAM_CAPTION_MAX_LEN];
+} telegram_pending_image_t;
+static telegram_pending_image_t telegram_pending_images[TELEGRAM_MAX_PENDING_IMAGES];
+static int telegram_pending_image_count = 0;
+
+// Home Assistant
+static bool ha_enabled = false;
+
+// Error overlay / WiFi failure tracking
+static bool error_overlay_enabled = false;
+static int wifi_fail_count = 0;
+
+// WiFi
+static bool wifi_performance_mode_enabled = true;
+
+// OTA
+static bool ota_check_enabled = true;
+
 // AI API Keys
 static char openai_api_key[AI_API_KEY_MAX_LEN] = {0};
 static char google_api_key[AI_API_KEY_MAX_LEN] = {0};
@@ -119,6 +147,85 @@ static void cron_persist(void)
         }
         nvs_commit(nvs_handle);
         nvs_close(nvs_handle);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Telegram pending-image list helpers (queue of images waiting for an
+// orientation-pairing partner). Joined-string NVS encoding mirrors the cron
+// helpers above: 0x1F separates path/caption within an entry, 0x1E separates
+// entries. Those control bytes can't appear in normal text, so no escaping is
+// needed even though captions may contain arbitrary UTF-8/newlines.
+// ----------------------------------------------------------------------------
+
+#define TELEGRAM_PENDING_JOINED_MAX \
+    (TELEGRAM_MAX_PENDING_IMAGES * (sizeof(((telegram_pending_image_t *) 0)->path) + \
+                                    TELEGRAM_CAPTION_MAX_LEN + 2))
+
+static void telegram_pending_persist(void)
+{
+    // static, not a stack local: this project's main task stack is only
+    // 6144 bytes and this buffer (TELEGRAM_MAX_PENDING_IMAGES * ~450 bytes)
+    // is called from deep within the Telegram poll's call chain, where
+    // stack headroom is already tight. config_manager runs single-threaded
+    // (main task only), so a static buffer here is safe.
+    static char joined[TELEGRAM_PENDING_JOINED_MAX];
+    size_t off = 0;
+    joined[0] = '\0';
+    for (int i = 0; i < telegram_pending_image_count; i++) {
+        int n = snprintf(joined + off, sizeof(joined) - off, "%s\x1F%s\x1E",
+                         telegram_pending_images[i].path, telegram_pending_images[i].caption);
+        if (n < 0 || (size_t) n >= sizeof(joined) - off) {
+            break;
+        }
+        off += (size_t) n;
+    }
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        if (telegram_pending_image_count > 0) {
+            nvs_set_str(nvs_handle, NVS_TELEGRAM_PENDING_LIST_KEY, joined);
+        } else {
+            nvs_erase_key(nvs_handle, NVS_TELEGRAM_PENDING_LIST_KEY);
+        }
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+}
+
+static void telegram_pending_load_from_joined(const char *joined)
+{
+    telegram_pending_image_count = 0;
+    if (!joined) {
+        return;
+    }
+    const char *p = joined;
+    while (*p != '\0' && telegram_pending_image_count < TELEGRAM_MAX_PENDING_IMAGES) {
+        const char *rec_end = strchr(p, '\x1E');
+        size_t rec_len = rec_end ? (size_t) (rec_end - p) : strlen(p);
+        const char *sep = memchr(p, '\x1F', rec_len);
+        if (sep) {
+            telegram_pending_image_t *e = &telegram_pending_images[telegram_pending_image_count];
+            size_t path_len = (size_t) (sep - p);
+            if (path_len >= sizeof(e->path)) {
+                path_len = sizeof(e->path) - 1;
+            }
+            memcpy(e->path, p, path_len);
+            e->path[path_len] = '\0';
+
+            size_t cap_len = rec_len - (size_t) (sep - p) - 1;
+            if (cap_len >= sizeof(e->caption)) {
+                cap_len = sizeof(e->caption) - 1;
+            }
+            memcpy(e->caption, sep + 1, cap_len);
+            e->caption[cap_len] = '\0';
+
+            telegram_pending_image_count++;
+        }
+        if (!rec_end) {
+            break;
+        }
+        p = rec_end + 1;
     }
 }
 
@@ -347,6 +454,88 @@ esp_err_t config_manager_init(void)
             ha_url[HA_URL_MAX_LEN - 1] = '\0';
             ESP_LOGI(TAG, "No HA URL in NVS, using default (empty)");
         }
+
+        uint8_t stored_ha_enabled;
+        if (nvs_get_u8(nvs_handle, NVS_HA_ENABLED_KEY, &stored_ha_enabled) == ESP_OK) {
+            ha_enabled = (stored_ha_enabled != 0);
+        } else {
+            // No explicit setting yet: preserve pre-existing behavior for a
+            // device that already had an HA URL configured before this
+            // switch existed; fresh/factory-reset devices default to off.
+            ha_enabled = (ha_url[0] != '\0');
+        }
+        ESP_LOGI(TAG, "Home Assistant integration: %s", ha_enabled ? "enabled" : "disabled");
+
+        // Telegram Bot
+        size_t tg_token_len = TELEGRAM_BOT_TOKEN_MAX_LEN;
+        if (nvs_get_str(nvs_handle, NVS_TELEGRAM_BOT_TOKEN_KEY, telegram_bot_token,
+                        &tg_token_len) == ESP_OK) {
+            ESP_LOGI(TAG, "Loaded Telegram bot token from NVS (length: %zu)", tg_token_len);
+        }
+
+        size_t tg_chat_id_len = TELEGRAM_CHAT_ID_MAX_LEN;
+        if (nvs_get_str(nvs_handle, NVS_TELEGRAM_CHAT_ID_KEY, telegram_chat_id, &tg_chat_id_len) ==
+            ESP_OK) {
+            ESP_LOGI(TAG, "Loaded Telegram chat ID from NVS (length: %zu)", tg_chat_id_len);
+        }
+
+        if (nvs_get_i64(nvs_handle, NVS_TELEGRAM_LAST_UPDATE_ID_KEY, &telegram_last_update_id) ==
+            ESP_OK) {
+            ESP_LOGI(TAG, "Loaded Telegram last update_id from NVS: %lld",
+                     (long long) telegram_last_update_id);
+        }
+
+        uint8_t stored_pairing = 1;  // Default to enabled
+        if (nvs_get_u8(nvs_handle, NVS_TELEGRAM_PAIRING_KEY, &stored_pairing) == ESP_OK) {
+            telegram_pairing_enabled = (stored_pairing != 0);
+        }
+        ESP_LOGI(TAG, "Telegram orientation pairing: %s",
+                 telegram_pairing_enabled ? "enabled" : "disabled");
+
+        uint8_t stored_low_batt_warned = 0;
+        if (nvs_get_u8(nvs_handle, NVS_TELEGRAM_LOW_BATT_WARNED_KEY, &stored_low_batt_warned) ==
+            ESP_OK) {
+            telegram_low_battery_warned = (stored_low_batt_warned != 0);
+        }
+
+        uint8_t stored_wake_notify = 0;
+        if (nvs_get_u8(nvs_handle, NVS_TELEGRAM_WAKE_NOTIFY_KEY, &stored_wake_notify) == ESP_OK) {
+            telegram_wake_notify_enabled = (stored_wake_notify != 0);
+        }
+
+        uint8_t stored_error_overlay = 0;
+        if (nvs_get_u8(nvs_handle, NVS_ERROR_OVERLAY_ENABLED_KEY, &stored_error_overlay) ==
+            ESP_OK) {
+            error_overlay_enabled = (stored_error_overlay != 0);
+        }
+
+        int32_t stored_wifi_fail_count = 0;
+        if (nvs_get_i32(nvs_handle, NVS_WIFI_FAIL_COUNT_KEY, &stored_wifi_fail_count) == ESP_OK) {
+            wifi_fail_count = (int) stored_wifi_fail_count;
+        }
+
+        uint8_t stored_wifi_perf = 1;  // Default to enabled (existing tiered behavior)
+        if (nvs_get_u8(nvs_handle, NVS_WIFI_PERF_MODE_ENABLED_KEY, &stored_wifi_perf) == ESP_OK) {
+            wifi_performance_mode_enabled = (stored_wifi_perf != 0);
+        }
+
+        {
+            static char pending_buf[TELEGRAM_PENDING_JOINED_MAX];
+            pending_buf[0] = '\0';
+            size_t pending_len = sizeof(pending_buf);
+            if (nvs_get_str(nvs_handle, NVS_TELEGRAM_PENDING_LIST_KEY, pending_buf, &pending_len) ==
+                ESP_OK) {
+                telegram_pending_load_from_joined(pending_buf);
+                ESP_LOGI(TAG, "Loaded %d pending Telegram pair image(s) from NVS",
+                         telegram_pending_image_count);
+            }
+        }
+
+        uint8_t stored_ota_check = 1;  // Default to enabled (unchanged prior behavior)
+        if (nvs_get_u8(nvs_handle, NVS_OTA_CHECK_ENABLED_KEY, &stored_ota_check) == ESP_OK) {
+            ota_check_enabled = (stored_ota_check != 0);
+        }
+        ESP_LOGI(TAG, "Automatic OTA check: %s", ota_check_enabled ? "enabled" : "disabled");
 
         // AI API Keys
         size_t openai_key_len = AI_API_KEY_MAX_LEN;
@@ -1052,6 +1241,307 @@ void config_manager_set_ha_url(const char *url)
 const char *config_manager_get_ha_url(void)
 {
     return ha_url;
+}
+
+void config_manager_set_ha_enabled(bool enabled)
+{
+    ha_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_HA_ENABLED_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Home Assistant integration %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_ha_enabled(void)
+{
+    return ha_enabled;
+}
+
+// ============================================================================
+// Telegram Bot
+// ============================================================================
+
+void config_manager_set_telegram_bot_token(const char *token)
+{
+    const char *new_token = token ? token : "";
+    strncpy(telegram_bot_token, new_token, TELEGRAM_BOT_TOKEN_MAX_LEN - 1);
+    telegram_bot_token[TELEGRAM_BOT_TOKEN_MAX_LEN - 1] = '\0';
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        if (telegram_bot_token[0] != '\0') {
+            nvs_set_str(nvs_handle, NVS_TELEGRAM_BOT_TOKEN_KEY, telegram_bot_token);
+        } else {
+            nvs_erase_key(nvs_handle, NVS_TELEGRAM_BOT_TOKEN_KEY);
+        }
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Telegram bot token %s", telegram_bot_token[0] ? "set" : "cleared");
+}
+
+const char *config_manager_get_telegram_bot_token(void)
+{
+    return telegram_bot_token;
+}
+
+void config_manager_set_telegram_chat_id(const char *chat_id)
+{
+    const char *new_id = chat_id ? chat_id : "";
+    strncpy(telegram_chat_id, new_id, TELEGRAM_CHAT_ID_MAX_LEN - 1);
+    telegram_chat_id[TELEGRAM_CHAT_ID_MAX_LEN - 1] = '\0';
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        if (telegram_chat_id[0] != '\0') {
+            nvs_set_str(nvs_handle, NVS_TELEGRAM_CHAT_ID_KEY, telegram_chat_id);
+        } else {
+            nvs_erase_key(nvs_handle, NVS_TELEGRAM_CHAT_ID_KEY);
+        }
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Telegram chat ID %s", telegram_chat_id[0] ? "set" : "cleared");
+}
+
+const char *config_manager_get_telegram_chat_id(void)
+{
+    return telegram_chat_id;
+}
+
+bool config_manager_telegram_is_configured(void)
+{
+    return telegram_bot_token[0] != '\0' && telegram_chat_id[0] != '\0';
+}
+
+void config_manager_set_telegram_last_update_id(int64_t update_id)
+{
+    telegram_last_update_id = update_id;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_i64(nvs_handle, NVS_TELEGRAM_LAST_UPDATE_ID_KEY, telegram_last_update_id);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Telegram last update_id set to: %lld", (long long) telegram_last_update_id);
+}
+
+int64_t config_manager_get_telegram_last_update_id(void)
+{
+    return telegram_last_update_id;
+}
+
+void config_manager_set_telegram_pairing_enabled(bool enabled)
+{
+    telegram_pairing_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_TELEGRAM_PAIRING_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Telegram orientation pairing %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_telegram_pairing_enabled(void)
+{
+    return telegram_pairing_enabled;
+}
+
+void config_manager_add_telegram_pending_image(const char *path, const char *caption)
+{
+    if (!path || path[0] == '\0') {
+        return;
+    }
+    if (telegram_pending_image_count >= TELEGRAM_MAX_PENDING_IMAGES) {
+        ESP_LOGW(TAG,
+                 "Telegram pending-pair queue full (%d), cannot track %s (file is still saved on "
+                 "storage)",
+                 TELEGRAM_MAX_PENDING_IMAGES, path);
+        return;
+    }
+
+    telegram_pending_image_t *e = &telegram_pending_images[telegram_pending_image_count++];
+    strncpy(e->path, path, sizeof(e->path) - 1);
+    e->path[sizeof(e->path) - 1] = '\0';
+    strncpy(e->caption, caption ? caption : "", sizeof(e->caption) - 1);
+    e->caption[sizeof(e->caption) - 1] = '\0';
+
+    telegram_pending_persist();
+    ESP_LOGI(TAG, "Queued %s for orientation pairing (%d pending)", path,
+             telegram_pending_image_count);
+}
+
+int config_manager_get_telegram_pending_image_count(void)
+{
+    return telegram_pending_image_count;
+}
+
+bool config_manager_get_telegram_pending_image_at(int index, char *path_out, size_t path_out_len,
+                                                  char *caption_out, size_t caption_out_len)
+{
+    if (index < 0 || index >= telegram_pending_image_count) {
+        return false;
+    }
+    if (path_out) {
+        snprintf(path_out, path_out_len, "%s", telegram_pending_images[index].path);
+    }
+    if (caption_out) {
+        snprintf(caption_out, caption_out_len, "%s", telegram_pending_images[index].caption);
+    }
+    return true;
+}
+
+void config_manager_remove_telegram_pending_image_at(int index)
+{
+    if (index < 0 || index >= telegram_pending_image_count) {
+        return;
+    }
+    for (int i = index; i < telegram_pending_image_count - 1; i++) {
+        telegram_pending_images[i] = telegram_pending_images[i + 1];
+    }
+    telegram_pending_image_count--;
+    telegram_pending_persist();
+}
+
+void config_manager_clear_telegram_pending_images(void)
+{
+    telegram_pending_image_count = 0;
+    telegram_pending_persist();
+    ESP_LOGI(TAG, "Cleared Telegram pending-pair queue (files were left on storage)");
+}
+
+void config_manager_set_telegram_low_battery_warned(bool warned)
+{
+    telegram_low_battery_warned = warned;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_TELEGRAM_LOW_BATT_WARNED_KEY, warned ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+}
+
+bool config_manager_get_telegram_low_battery_warned(void)
+{
+    return telegram_low_battery_warned;
+}
+
+void config_manager_set_telegram_wake_notify_enabled(bool enabled)
+{
+    telegram_wake_notify_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_TELEGRAM_WAKE_NOTIFY_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Telegram wake-up notification %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_telegram_wake_notify_enabled(void)
+{
+    return telegram_wake_notify_enabled;
+}
+
+// ============================================================================
+// Error overlay / WiFi failure tracking
+// ============================================================================
+
+void config_manager_set_error_overlay_enabled(bool enabled)
+{
+    error_overlay_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_ERROR_OVERLAY_ENABLED_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Critical-error display overlay %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_error_overlay_enabled(void)
+{
+    return error_overlay_enabled;
+}
+
+void config_manager_set_wifi_fail_count(int count)
+{
+    wifi_fail_count = count;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_i32(nvs_handle, NVS_WIFI_FAIL_COUNT_KEY, (int32_t) wifi_fail_count);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+}
+
+int config_manager_get_wifi_fail_count(void)
+{
+    return wifi_fail_count;
+}
+
+// ============================================================================
+// WiFi
+// ============================================================================
+
+void config_manager_set_wifi_performance_mode_enabled(bool enabled)
+{
+    wifi_performance_mode_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_WIFI_PERF_MODE_ENABLED_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "WiFi performance mode %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_wifi_performance_mode_enabled(void)
+{
+    return wifi_performance_mode_enabled;
+}
+
+// ============================================================================
+// OTA
+// ============================================================================
+
+void config_manager_set_ota_check_enabled(bool enabled)
+{
+    ota_check_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_OTA_CHECK_ENABLED_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Automatic OTA check %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_ota_check_enabled(void)
+{
+    return ota_check_enabled;
 }
 
 // ============================================================================

--- a/main/config_manager.c
+++ b/main/config_manager.c
@@ -80,6 +80,7 @@ static int wifi_fail_count = 0;
 static bool wifi_performance_mode_enabled = true;
 static bool rotation_pairing_enabled = false;
 static bool telegram_rotation_notify_enabled = false;
+static bool telegram_keep_originals_enabled = false;
 
 // OTA
 static bool ota_check_enabled = true;
@@ -540,6 +541,12 @@ esp_err_t config_manager_init(void)
         if (nvs_get_u8(nvs_handle, NVS_TELEGRAM_ROTATION_NOTIFY_KEY, &stored_rotation_notify) ==
             ESP_OK) {
             telegram_rotation_notify_enabled = (stored_rotation_notify != 0);
+        }
+
+        uint8_t stored_keep_originals = 0;
+        if (nvs_get_u8(nvs_handle, NVS_TELEGRAM_KEEP_ORIGINALS_KEY, &stored_keep_originals) ==
+            ESP_OK) {
+            telegram_keep_originals_enabled = (stored_keep_originals != 0);
         }
 
         {
@@ -1580,6 +1587,25 @@ void config_manager_set_telegram_rotation_notify_enabled(bool enabled)
 bool config_manager_get_telegram_rotation_notify_enabled(void)
 {
     return telegram_rotation_notify_enabled;
+}
+
+void config_manager_set_telegram_keep_originals_enabled(bool enabled)
+{
+    telegram_keep_originals_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_TELEGRAM_KEEP_ORIGINALS_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Telegram keep-originals %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_telegram_keep_originals_enabled(void)
+{
+    return telegram_keep_originals_enabled;
 }
 
 // ============================================================================

--- a/main/config_manager.c
+++ b/main/config_manager.c
@@ -79,6 +79,7 @@ static int wifi_fail_count = 0;
 // WiFi
 static bool wifi_performance_mode_enabled = true;
 static bool rotation_pairing_enabled = false;
+static bool telegram_rotation_notify_enabled = false;
 
 // OTA
 static bool ota_check_enabled = true;
@@ -524,6 +525,12 @@ esp_err_t config_manager_init(void)
         if (nvs_get_u8(nvs_handle, NVS_ROTATION_PAIRING_ENABLED_KEY, &stored_rotation_pairing) ==
             ESP_OK) {
             rotation_pairing_enabled = (stored_rotation_pairing != 0);
+        }
+
+        uint8_t stored_rotation_notify = 0;
+        if (nvs_get_u8(nvs_handle, NVS_TELEGRAM_ROTATION_NOTIFY_KEY, &stored_rotation_notify) ==
+            ESP_OK) {
+            telegram_rotation_notify_enabled = (stored_rotation_notify != 0);
         }
 
         {
@@ -1545,6 +1552,25 @@ void config_manager_set_rotation_pairing_enabled(bool enabled)
 bool config_manager_get_rotation_pairing_enabled(void)
 {
     return rotation_pairing_enabled;
+}
+
+void config_manager_set_telegram_rotation_notify_enabled(bool enabled)
+{
+    telegram_rotation_notify_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_TELEGRAM_ROTATION_NOTIFY_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Telegram fallback-rotation notification %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_telegram_rotation_notify_enabled(void)
+{
+    return telegram_rotation_notify_enabled;
 }
 
 // ============================================================================

--- a/main/config_manager.c
+++ b/main/config_manager.c
@@ -78,6 +78,7 @@ static int wifi_fail_count = 0;
 
 // WiFi
 static bool wifi_performance_mode_enabled = true;
+static bool rotation_pairing_enabled = false;
 
 // OTA
 static bool ota_check_enabled = true;
@@ -517,6 +518,12 @@ esp_err_t config_manager_init(void)
         uint8_t stored_wifi_perf = 1;  // Default to enabled (existing tiered behavior)
         if (nvs_get_u8(nvs_handle, NVS_WIFI_PERF_MODE_ENABLED_KEY, &stored_wifi_perf) == ESP_OK) {
             wifi_performance_mode_enabled = (stored_wifi_perf != 0);
+        }
+
+        uint8_t stored_rotation_pairing = 0;
+        if (nvs_get_u8(nvs_handle, NVS_ROTATION_PAIRING_ENABLED_KEY, &stored_rotation_pairing) ==
+            ESP_OK) {
+            rotation_pairing_enabled = (stored_rotation_pairing != 0);
         }
 
         {
@@ -1519,6 +1526,25 @@ void config_manager_set_wifi_performance_mode_enabled(bool enabled)
 bool config_manager_get_wifi_performance_mode_enabled(void)
 {
     return wifi_performance_mode_enabled;
+}
+
+void config_manager_set_rotation_pairing_enabled(bool enabled)
+{
+    rotation_pairing_enabled = enabled;
+
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle) == ESP_OK) {
+        nvs_set_u8(nvs_handle, NVS_ROTATION_PAIRING_ENABLED_KEY, enabled ? 1 : 0);
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Auto-rotate orientation pairing %s", enabled ? "enabled" : "disabled");
+}
+
+bool config_manager_get_rotation_pairing_enabled(void)
+{
+    return rotation_pairing_enabled;
 }
 
 // ============================================================================

--- a/main/config_manager.h
+++ b/main/config_manager.h
@@ -221,6 +221,12 @@ bool config_manager_get_rotation_pairing_enabled(void);
 void config_manager_set_telegram_rotation_notify_enabled(bool enabled);
 bool config_manager_get_telegram_rotation_notify_enabled(void);
 
+// Keep a copy of each Telegram photo exactly as received (pre-processing) in
+// TELEGRAM_ORIGINALS_DIRECTORY. Defaults to false. See
+// NVS_TELEGRAM_KEEP_ORIGINALS_KEY in config.h.
+void config_manager_set_telegram_keep_originals_enabled(bool enabled);
+bool config_manager_get_telegram_keep_originals_enabled(void);
+
 // ============================================================================
 // OTA
 // ============================================================================

--- a/main/config_manager.h
+++ b/main/config_manager.h
@@ -118,6 +118,63 @@ const char *config_manager_get_image_etag(void);
 void config_manager_set_ha_url(const char *url);
 const char *config_manager_get_ha_url(void);
 
+// Master switch for all Home Assistant integration (online/offline/update
+// notifications and the rotation-veto piggyback). Defaults to false on a
+// fresh device; a device upgrading from a firmware version that predates
+// this switch keeps HA enabled automatically if a ha_url was already
+// configured, so existing setups don't silently break.
+void config_manager_set_ha_enabled(bool enabled);
+bool config_manager_get_ha_enabled(void);
+
+// ============================================================================
+// Telegram Bot
+// ============================================================================
+
+void config_manager_set_telegram_bot_token(const char *token);
+const char *config_manager_get_telegram_bot_token(void);
+
+void config_manager_set_telegram_chat_id(const char *chat_id);
+const char *config_manager_get_telegram_chat_id(void);
+
+// True once both a bot token and a chat ID are configured.
+bool config_manager_telegram_is_configured(void);
+
+// Highest Telegram update_id processed so far (0 = none yet). The next
+// getUpdates poll should request offset = value + 1.
+void config_manager_set_telegram_last_update_id(int64_t update_id);
+int64_t config_manager_get_telegram_last_update_id(void);
+
+// Orientation-pairing mode: combine two mismatched-orientation Telegram
+// photos into one composed image instead of ever showing one alone.
+// Togglable via the web UI and the "/pairing" bot command.
+void config_manager_set_telegram_pairing_enabled(bool enabled);
+bool config_manager_get_telegram_pairing_enabled(void);
+
+// Queue of images waiting for an orientation partner (FIFO - oldest first).
+// Every mismatched image is appended here, not just one, so nothing is lost
+// if several arrive before a partner shows up. Persisted so it survives deep
+// sleep even on MemFS-only boards where the files themselves won't (callers
+// should stat() before trusting a path is still there).
+void config_manager_add_telegram_pending_image(const char *path, const char *caption);
+int config_manager_get_telegram_pending_image_count(void);
+bool config_manager_get_telegram_pending_image_at(int index, char *path_out, size_t path_out_len,
+                                                  char *caption_out, size_t caption_out_len);
+void config_manager_remove_telegram_pending_image_at(int index);
+// Clears the tracking queue only - does NOT delete the underlying files
+// (they remain on storage like any other received image).
+void config_manager_clear_telegram_pending_images(void);
+
+// Whether a low-battery Telegram warning has already been sent for the
+// current discharge episode (cleared once the battery recovers), so the
+// warning fires once rather than on every poll.
+void config_manager_set_telegram_low_battery_warned(bool warned);
+bool config_manager_get_telegram_low_battery_warned(void);
+
+// Wake-up status ping (SSID/IP/battery/wake reason/rotation schedule) sent to
+// Telegram on every poll, even when there are no new updates.
+void config_manager_set_telegram_wake_notify_enabled(bool enabled);
+bool config_manager_get_telegram_wake_notify_enabled(void);
+
 // ============================================================================
 // AI API Keys
 // ============================================================================
@@ -127,6 +184,39 @@ const char *config_manager_get_openai_api_key(void);
 
 void config_manager_set_google_api_key(const char *key);
 const char *config_manager_get_google_api_key(void);
+
+// ============================================================================
+// Error overlay / WiFi failure tracking
+// ============================================================================
+
+// On-display error overlay for persistent failures (currently: repeated WiFi
+// connect failure on a scheduled wake). Togglable via web UI and bot command.
+void config_manager_set_error_overlay_enabled(bool enabled);
+bool config_manager_get_error_overlay_enabled(void);
+
+// Consecutive scheduled-wake WiFi connection failures (reset to 0 on any
+// success). Persisted so it survives deep sleep between wakes.
+void config_manager_set_wifi_fail_count(int count);
+int config_manager_get_wifi_fail_count(void);
+
+// ============================================================================
+// WiFi
+// ============================================================================
+
+// When false, WiFi always stays in power-save mode regardless of the
+// interactive/USB-triggered "full RX" policy in power_manager - lower draw,
+// slower web UI. Defaults to true (existing tiered behavior unchanged).
+void config_manager_set_wifi_performance_mode_enabled(bool enabled);
+bool config_manager_get_wifi_performance_mode_enabled(void);
+
+// ============================================================================
+// OTA
+// ============================================================================
+
+// Automatic OTA checks (periodic + cold-boot). A manual "check now" from the
+// web UI is unaffected by this setting.
+void config_manager_set_ota_check_enabled(bool enabled);
+bool config_manager_get_ota_check_enabled(void);
 
 // ============================================================================
 // Power

--- a/main/config_manager.h
+++ b/main/config_manager.h
@@ -215,6 +215,12 @@ bool config_manager_get_wifi_performance_mode_enabled(void);
 void config_manager_set_rotation_pairing_enabled(bool enabled);
 bool config_manager_get_rotation_pairing_enabled(void);
 
+// Send a thumbnail to Telegram whenever a Telegram-mode wake falls back to
+// album rotation (no new Telegram image). Defaults to false. See
+// NVS_TELEGRAM_ROTATION_NOTIFY_KEY in config.h.
+void config_manager_set_telegram_rotation_notify_enabled(bool enabled);
+bool config_manager_get_telegram_rotation_notify_enabled(void);
+
 // ============================================================================
 // OTA
 // ============================================================================

--- a/main/config_manager.h
+++ b/main/config_manager.h
@@ -209,6 +209,12 @@ int config_manager_get_wifi_fail_count(void);
 void config_manager_set_wifi_performance_mode_enabled(bool enabled);
 bool config_manager_get_wifi_performance_mode_enabled(void);
 
+// Orientation pairing during normal (non-Telegram) auto-rotation - random
+// mode only. Defaults to false. See NVS_ROTATION_PAIRING_ENABLED_KEY in
+// config.h.
+void config_manager_set_rotation_pairing_enabled(bool enabled);
+bool config_manager_get_rotation_pairing_enabled(void);
+
 // ============================================================================
 // OTA
 // ============================================================================

--- a/main/display_manager.c
+++ b/main/display_manager.c
@@ -1,9 +1,11 @@
 #include "display_manager.h"
 
 #include <dirent.h>
+#include <stdio.h>
 #include <string.h>
 #include <strings.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "GUI_BMPfile.h"
@@ -22,25 +24,15 @@
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
+#include "history_manager.h"
+#include "image_processor.h"
 #include "nvs.h"
+#include "processing_settings.h"
 #include "storage.h"
 #include "utils.h"
 
 static const char *TAG = "display_manager";
 #define NVS_LAST_IMAGE_KEY "last_image"
-
-// Grayscale (gc*) panels take linear-intensity nibbles (0=black..15=white)
-// rather than Spectra ink-color indices, so both the decode mapping and the
-// "white" fill value depend on the display type.
-static bool display_is_grayscale(void)
-{
-    return strncmp(BOARD_HAL_DISPLAY_TYPE, "gc", 2) == 0;
-}
-
-static UWORD display_white_color(void)
-{
-    return display_is_grayscale() ? 0xF : EPD_7IN3E_WHITE;
-}
 
 static SemaphoreHandle_t display_mutex = NULL;
 static char current_image[64] = {0};
@@ -48,21 +40,6 @@ static char last_displayed_image[256] = {0};  // Internal state: last displayed 
 
 static uint8_t *epd_image_buffer = NULL;
 static uint32_t image_buffer_size;
-
-// Load last displayed image from NVS
-static void load_last_displayed_image(void)
-{
-    nvs_handle_t nvs_handle;
-    if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &nvs_handle) == ESP_OK) {
-        size_t len = sizeof(last_displayed_image);
-        if (nvs_get_str(nvs_handle, NVS_LAST_IMAGE_KEY, last_displayed_image, &len) == ESP_OK) {
-            ESP_LOGI(TAG, "Loaded last displayed image: %s", last_displayed_image);
-        } else {
-            last_displayed_image[0] = '\0';
-        }
-        nvs_close(nvs_handle);
-    }
-}
 
 // Save last displayed image to NVS
 static void save_last_displayed_image(const char *filename)
@@ -125,8 +102,8 @@ esp_err_t display_manager_init(void)
 void display_manager_initialize_paint(void)
 {
     Paint_NewImage(epd_image_buffer, BOARD_HAL_DISPLAY_WIDTH, BOARD_HAL_DISPLAY_HEIGHT,
-                   config_manager_get_display_rotation_deg() % 360, display_white_color());
-    Paint_SetScale(display_is_grayscale() ? 16 : 6);
+                   config_manager_get_display_rotation_deg() % 360, EPD_7IN3E_WHITE);
+    Paint_SetScale(6);
     Paint_SelectImage(epd_image_buffer);
 }
 
@@ -146,7 +123,7 @@ esp_err_t display_manager_show_image(const char *filename)
     ESP_LOGI(TAG, "Free heap before display: %lu bytes", esp_get_free_heap_size());
 
     ESP_LOGI(TAG, "Clearing display buffer");
-    Paint_Clear(display_white_color());
+    Paint_Clear(EPD_7IN3E_WHITE);
 
     // Detect file type by extension
     const char *ext = strrchr(filename, '.');
@@ -163,18 +140,14 @@ esp_err_t display_manager_show_image(const char *filename)
         }
     } else if (is_png) {
         ESP_LOGI(TAG, "Reading PNG file into buffer");
-        UBYTE result = display_is_grayscale() ? GUI_ReadPng_Gray16(filename, 0, 0)
-                                              : GUI_ReadPng_RGB_6Color(filename, 0, 0);
-        if (result != 0) {
+        if (GUI_ReadPng_RGB_6Color(filename, 0, 0) != 0) {
             ESP_LOGE(TAG, "Failed to read PNG file");
             xSemaphoreGive(display_mutex);
             return ESP_FAIL;
         }
     } else {
         ESP_LOGI(TAG, "Reading BMP file into buffer");
-        UBYTE result = display_is_grayscale() ? GUI_ReadBmp_RGB_Gray16(filename, 0, 0)
-                                              : GUI_ReadBmp_RGB_6Color(filename, 0, 0);
-        if (result != 0) {
+        if (GUI_ReadBmp_RGB_6Color(filename, 0, 0) != 0) {
             ESP_LOGE(TAG, "Failed to read BMP file");
             xSemaphoreGive(display_mutex);
             return ESP_FAIL;
@@ -201,6 +174,13 @@ esp_err_t display_manager_show_image(const char *filename)
 
     xSemaphoreGive(display_mutex);
 
+    // Single choke point for every successful display, regardless of source
+    // (rotation, manual web-UI pick, Telegram) - keeps the "shown until a
+    // full cycle completes" history consistent everywhere. Idempotent: a
+    // repeated path (e.g. the fixed URL-rotation temp file) is a no-op after
+    // the first call.
+    history_manager_mark_shown(filename);
+
     ESP_LOGI(TAG, "Image displayed successfully");
     return ESP_OK;
 }
@@ -220,13 +200,10 @@ esp_err_t display_manager_show_rgb_buffer(const uint8_t *rgb_buffer, int width, 
     ESP_LOGI(TAG, "Free heap before display: %lu bytes", esp_get_free_heap_size());
 
     ESP_LOGI(TAG, "Clearing display buffer");
-    Paint_Clear(display_white_color());
+    Paint_Clear(EPD_7IN3E_WHITE);
 
     ESP_LOGI(TAG, "Painting RGB buffer to display");
-    UBYTE result = display_is_grayscale()
-                       ? GUI_DisplayRGBBuffer_Gray16(rgb_buffer, width, height, 0, 0)
-                       : GUI_DisplayRGBBuffer_6Color(rgb_buffer, width, height, 0, 0);
-    if (result != 0) {
+    if (GUI_DisplayRGBBuffer_6Color(rgb_buffer, width, height, 0, 0) != 0) {
         ESP_LOGE(TAG, "Failed to paint RGB buffer");
         xSemaphoreGive(display_mutex);
         return ESP_FAIL;
@@ -283,7 +260,8 @@ esp_err_t display_manager_show_calibration(void)
 
     // Draw the calibration pattern directly to the buffer. Grayscale (GC16)
     // panels get a 16-level gray step wedge instead of the 6-color swatches.
-    if (display_is_grayscale()) {
+    if (strncmp(BOARD_HAL_DISPLAY_TYPE, "gc", 2) == 0) {
+        Paint_SetScale(16);
         Paint_DrawGrayscaleCalibrationPattern();
     } else {
         Paint_DrawCalibrationPattern();
@@ -387,6 +365,120 @@ static void rotate_sequential(char **enabled_albums, int album_count)
     }
 }
 
+// Whether the frame is currently mounted in portrait as *actually rendered*.
+// Mirrors telegram_bot.c's wants_portrait_frame_now() - kept as a separate,
+// tiny duplicate rather than a cross-module dependency between these two
+// already-large files.
+static bool wants_portrait_frame(void)
+{
+    int rot = config_manager_get_display_rotation_deg() % 360;
+    if (rot < 0) {
+        rot += 360;
+    }
+    return (rot == 90 || rot == 270);
+}
+
+static esp_err_t read_whole_file_dm(const char *path, uint8_t **out_data, long *out_size)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        return ESP_FAIL;
+    }
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size <= 0) {
+        fclose(f);
+        return ESP_FAIL;
+    }
+    uint8_t *buf = heap_caps_malloc((size_t) size, MALLOC_CAP_SPIRAM);
+    if (!buf) {
+        fclose(f);
+        return ESP_ERR_NO_MEM;
+    }
+    size_t read_bytes = fread(buf, 1, (size_t) size, f);
+    fclose(f);
+    if (read_bytes != (size_t) size) {
+        heap_caps_free(buf);
+        return ESP_FAIL;
+    }
+    *out_data = buf;
+    *out_size = size;
+    return ESP_OK;
+}
+
+// Composes two mismatched-orientation album images into one, saved as a new
+// permanent file in dest_album_path - same idea as telegram_bot.c's
+// orientation pairing, applied to normal auto-rotation instead of Telegram
+// receives. Both source files are left untouched (caller's choice to keep
+// them as independently rotatable images too).
+static esp_err_t compose_rotation_pair(const char *path_a, const char *path_b,
+                                       const char *dest_album_path, char *out_path,
+                                       size_t out_path_len)
+{
+    uint8_t *buf_a = NULL, *buf_b = NULL;
+    long size_a = 0, size_b = 0;
+
+    esp_err_t err = read_whole_file_dm(path_a, &buf_a, &size_a);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = read_whole_file_dm(path_b, &buf_b, &size_b);
+    if (err != ESP_OK) {
+        heap_caps_free(buf_a);
+        return err;
+    }
+
+    image_format_t format_a = image_processor_detect_format(path_a);
+    image_format_t format_b = image_processor_detect_format(path_b);
+    dither_algorithm_t algo = processing_settings_get_dithering_algorithm();
+
+    image_process_rgb_result_t result;
+    err = image_processor_compose_pair_to_rgb(buf_a, (size_t) size_a, format_a, buf_b,
+                                              (size_t) size_b, format_b, wants_portrait_frame(),
+                                              algo, &result);
+    heap_caps_free(buf_a);
+    heap_caps_free(buf_b);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    time_t now = time(NULL);
+    for (int suffix = 0; suffix < 100; suffix++) {
+        if (suffix == 0) {
+            snprintf(out_path, out_path_len, "%s/combined_%lld.png", dest_album_path,
+                     (long long) now);
+        } else {
+            snprintf(out_path, out_path_len, "%s/combined_%lld_%d.png", dest_album_path,
+                     (long long) now, suffix);
+        }
+        struct stat st;
+        if (stat(out_path, &st) != 0) {
+            break;  // path is free
+        }
+    }
+
+    err = image_processor_write_rgb_to_png(result.rgb_data, result.width, result.height, out_path);
+    heap_caps_free(result.rgb_data);
+    return err;
+}
+
+// Peeks orientation for a single candidate; only PNG/JPG carry a meaningful
+// source aspect ratio to check (BMP/EPDGZ are treated as already
+// display-appropriate, same as in telegram_bot.c's pairing).
+static bool image_orientation_mismatches(const char *path, bool wants_portrait)
+{
+    image_format_t fmt = image_processor_detect_format(path);
+    if (fmt != IMAGE_FORMAT_PNG && fmt != IMAGE_FORMAT_JPG) {
+        return false;
+    }
+    int w = 0, h = 0;
+    if (image_processor_peek_file_dimensions(path, fmt, &w, &h) != ESP_OK || w <= 0 || h <= 0) {
+        return false;
+    }
+    return (h > w) != wants_portrait;
+}
+
 static void rotate_random(char **enabled_albums, int album_count)
 {
     ESP_LOGI(TAG, "Random rotation mode");
@@ -474,37 +566,102 @@ static void rotate_random(char **enabled_albums, int album_count)
         return;
     }
 
-    // Load last displayed image if not already loaded
-    if (last_displayed_image[0] == '\0') {
-        load_last_displayed_image();
-    }
-
-    // Select random image, avoiding the last displayed image if possible
-    int random_index = esp_random() % total_image_count;
-
-    // If we have more than one image and the random selection matches the last image,
-    // try to pick a different one (up to 10 attempts)
-    if (total_image_count > 1 && last_displayed_image[0] != '\0') {
-        int attempts = 0;
-        while (attempts < 10 && strcmp(image_list[random_index], last_displayed_image) == 0) {
-            random_index = esp_random() % total_image_count;
-            attempts++;
+    // Pick among images not yet shown this cycle (history_manager). If every
+    // image in the enabled albums has already been shown, the cycle is
+    // complete: clear the history and start a fresh one over the full set.
+    // This also inherently avoids repeating the last-shown image whenever
+    // more than one image remains unseen, so no separate retry-loop is
+    // needed for that anymore.
+    int *unseen = malloc((size_t) total_image_count * sizeof(int));
+    if (!unseen) {
+        ESP_LOGE(TAG, "Failed to allocate unseen-index list");
+        for (int i = 0; i < total_image_count; i++) {
+            free(image_list[i]);
         }
-
-        if (strcmp(image_list[random_index], last_displayed_image) == 0) {
-            ESP_LOGW(TAG, "Could not avoid repeating last image after 10 attempts");
-        } else {
-            ESP_LOGI(TAG, "Successfully avoided repeating last image");
+        free(image_list);
+        return;
+    }
+    int unseen_count = 0;
+    for (int i = 0; i < total_image_count; i++) {
+        if (!history_manager_has_shown(image_list[i])) {
+            unseen[unseen_count++] = i;
         }
     }
+    if (unseen_count == 0) {
+        ESP_LOGI(TAG, "Display history cycle complete (%d images shown) - starting a new cycle",
+                 total_image_count);
+        history_manager_clear();
+        for (int i = 0; i < total_image_count; i++) {
+            unseen[unseen_count++] = i;
+        }
+    }
+
+    int random_index = unseen[esp_random() % unseen_count];
+    free(unseen);
+
+    const char *display_path = image_list[random_index];
+    char composed_path[512];
+    bool use_composed = false;
+
+    // Orientation pairing (opt-in, random mode only - see
+    // config_manager_get_rotation_pairing_enabled()): if the picked image
+    // doesn't match the panel's orientation, look for another mismatched
+    // image in the same candidate pool and combine them instead of showing
+    // one letterboxed.
+    if (config_manager_get_rotation_pairing_enabled()) {
+        bool wants_portrait = wants_portrait_frame();
+        if (image_orientation_mismatches(display_path, wants_portrait)) {
+            int partner_index = -1;
+            for (int i = 0; i < total_image_count; i++) {
+                if (i == random_index) {
+                    continue;
+                }
+                if (image_orientation_mismatches(image_list[i], wants_portrait)) {
+                    partner_index = i;
+                    break;
+                }
+            }
+
+            if (partner_index >= 0) {
+                // Save the combined result into the primary pick's own
+                // album directory.
+                char dest_album_path[512];
+                strncpy(dest_album_path, display_path, sizeof(dest_album_path) - 1);
+                dest_album_path[sizeof(dest_album_path) - 1] = '\0';
+                char *slash = strrchr(dest_album_path, '/');
+                if (slash) {
+                    *slash = '\0';
+                }
+
+                esp_err_t err = compose_rotation_pair(display_path, image_list[partner_index],
+                                                      dest_album_path, composed_path,
+                                                      sizeof(composed_path));
+                if (err == ESP_OK) {
+                    ESP_LOGI(TAG, "Auto-rotate: combined %s + %s -> %s", display_path,
+                             image_list[partner_index], composed_path);
+                    // The sources stay in their album (still independently
+                    // rotatable later) but count as shown for this cycle,
+                    // same as the combined result itself will once displayed.
+                    history_manager_mark_shown(display_path);
+                    history_manager_mark_shown(image_list[partner_index]);
+                    use_composed = true;
+                } else {
+                    ESP_LOGW(TAG, "Auto-rotate: failed to combine %s + %s: %s", display_path,
+                             image_list[partner_index], esp_err_to_name(err));
+                }
+            }
+        }
+    }
+
+    const char *final_path = use_composed ? composed_path : display_path;
 
     // Display random image
-    ESP_LOGI(TAG, "Auto-rotate: Displaying random image %d/%d: %s", random_index + 1,
-             total_image_count, image_list[random_index]);
-    display_manager_show_image(image_list[random_index]);
+    ESP_LOGI(TAG, "Auto-rotate: Displaying random image %d/%d (unseen this cycle: %d): %s",
+             random_index + 1, total_image_count, unseen_count, final_path);
+    display_manager_show_image(final_path);
 
     // Store the displayed image filename in NVS
-    save_last_displayed_image(image_list[random_index]);
+    save_last_displayed_image(final_path);
 
     // Free image list
     for (int i = 0; i < total_image_count; i++) {

--- a/main/display_manager.c
+++ b/main/display_manager.c
@@ -14,6 +14,7 @@
 #include "GUI_Paint.h"
 #include "GUI_RawBuffer.h"
 #include "album_manager.h"
+#include "battery_history.h"
 #include "board_hal.h"
 #include "config.h"
 #include "config_manager.h"
@@ -180,6 +181,10 @@ esp_err_t display_manager_show_image(const char *filename)
     // repeated path (e.g. the fixed URL-rotation temp file) is a no-op after
     // the first call.
     history_manager_mark_shown(filename);
+
+    // One battery reading per successfully displayed image - see
+    // battery_history.c for the persisted log and reset policy.
+    battery_history_record();
 
     ESP_LOGI(TAG, "Image displayed successfully");
     return ESP_OK;

--- a/main/ha_integration.c
+++ b/main/ha_integration.c
@@ -40,6 +40,9 @@ static esp_err_t ha_http_event_handler(esp_http_client_event_t *evt)
 
 bool ha_is_configured(void)
 {
+    if (!config_manager_get_ha_enabled()) {
+        return false;
+    }
     const char *ha_url = config_manager_get_ha_url();
     return (ha_url != NULL && strlen(ha_url) > 0);
 }

--- a/main/history_manager.c
+++ b/main/history_manager.c
@@ -1,0 +1,119 @@
+#include "history_manager.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "config.h"
+#include "esp_log.h"
+#include "storage.h"
+
+static const char *TAG = "history_manager";
+
+static char **s_paths = NULL;
+static int s_count = 0;
+static int s_capacity = 0;
+
+static bool grow_if_needed(void)
+{
+    if (s_count < s_capacity) {
+        return true;
+    }
+    int new_capacity = (s_capacity == 0) ? 32 : s_capacity * 2;
+    char **grown = realloc(s_paths, (size_t) new_capacity * sizeof(char *));
+    if (!grown) {
+        ESP_LOGE(TAG, "Failed to grow display-history array");
+        return false;
+    }
+    s_paths = grown;
+    s_capacity = new_capacity;
+    return true;
+}
+
+esp_err_t history_manager_init(void)
+{
+    if (!storage_has_persistent_storage()) {
+        ESP_LOGI(TAG, "No persistent storage - display history is RAM-only for this session");
+        return ESP_OK;
+    }
+
+    FILE *f = fopen(DISPLAY_HISTORY_PATH, "r");
+    if (!f) {
+        return ESP_OK;  // No history file yet - fresh start.
+    }
+
+    char line[320];
+    while (fgets(line, sizeof(line), f)) {
+        size_t len = strlen(line);
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+            line[--len] = '\0';
+        }
+        if (len == 0 || !grow_if_needed()) {
+            continue;
+        }
+        s_paths[s_count] = strdup(line);
+        if (s_paths[s_count]) {
+            s_count++;
+        }
+    }
+    fclose(f);
+    ESP_LOGI(TAG, "Loaded %d display-history entries", s_count);
+    return ESP_OK;
+}
+
+bool history_manager_has_shown(const char *image_path)
+{
+    if (!image_path) {
+        return false;
+    }
+    for (int i = 0; i < s_count; i++) {
+        if (strcmp(s_paths[i], image_path) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void history_manager_mark_shown(const char *image_path)
+{
+    if (!image_path || history_manager_has_shown(image_path)) {
+        return;
+    }
+    if (!grow_if_needed()) {
+        return;
+    }
+    s_paths[s_count] = strdup(image_path);
+    if (!s_paths[s_count]) {
+        return;
+    }
+    s_count++;
+
+    if (!storage_has_persistent_storage()) {
+        return;
+    }
+    FILE *f = fopen(DISPLAY_HISTORY_PATH, "a");
+    if (!f) {
+        ESP_LOGW(TAG, "Failed to open display-history file for append");
+        return;
+    }
+    fprintf(f, "%s\n", image_path);
+    fclose(f);
+}
+
+void history_manager_clear(void)
+{
+    for (int i = 0; i < s_count; i++) {
+        free(s_paths[i]);
+    }
+    s_count = 0;
+
+    if (storage_has_persistent_storage()) {
+        remove(DISPLAY_HISTORY_PATH);
+    }
+    ESP_LOGI(TAG, "Display history cleared");
+}
+
+int history_manager_count(void)
+{
+    return s_count;
+}

--- a/main/history_manager.h
+++ b/main/history_manager.h
@@ -1,0 +1,37 @@
+#ifndef HISTORY_MANAGER_H
+#define HISTORY_MANAGER_H
+
+#include <stdbool.h>
+
+#include "esp_err.h"
+
+// Tracks which images have already been shown (identified by their full
+// storage path) so random rotation - and the Telegram-mode fallback
+// rotation - can cycle through every image once before repeating. Persisted
+// to a plain-text file on persistent storage (SD card or internal flash),
+// one path per line, so the history survives a reboot; falls back to
+// RAM-only tracking for the current session if no persistent storage is
+// mounted.
+
+// Loads the history file (if any) into RAM. Call once at boot, after
+// storage_init(). Always returns ESP_OK - a missing/unreadable file just
+// means an empty history.
+esp_err_t history_manager_init(void);
+
+// True if this exact path has already been marked shown since the last
+// clear.
+bool history_manager_has_shown(const char *image_path);
+
+// Marks a path as shown. No-op if it's already marked (keeps the history
+// file from growing on repeated calls for the same path, e.g. a fixed
+// "current image" temp file).
+void history_manager_mark_shown(const char *image_path);
+
+// Clears the whole history (RAM and the persisted file), starting a fresh
+// cycle.
+void history_manager_clear(void);
+
+// Number of entries currently tracked.
+int history_manager_count(void);
+
+#endif

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -1679,6 +1679,8 @@ static esp_err_t config_handler(httpd_req_t *req)
         rotation_mode_t rm = config_manager_get_rotation_mode();
         if (rm == ROTATION_MODE_URL)
             rotation_mode_str = "url";
+        else if (rm == ROTATION_MODE_TELEGRAM)
+            rotation_mode_str = "telegram";
         cJSON_AddStringToObject(root, "rotation_mode", rotation_mode_str);
 
         // Auto Rotate - SDCARD
@@ -1716,6 +1718,18 @@ static esp_err_t config_handler(httpd_req_t *req)
         // Home Assistant
         const char *ha_url = config_manager_get_ha_url();
         cJSON_AddStringToObject(root, "ha_url", ha_url ? ha_url : "");
+        cJSON_AddBoolToObject(root, "ha_enabled", config_manager_get_ha_enabled());
+
+        // Telegram Bot
+        const char *tg_token = config_manager_get_telegram_bot_token();
+        cJSON_AddStringToObject(root, "telegram_bot_token", tg_token ? tg_token : "");
+        const char *tg_chat_id = config_manager_get_telegram_chat_id();
+        cJSON_AddStringToObject(root, "telegram_chat_id", tg_chat_id ? tg_chat_id : "");
+        cJSON_AddBoolToObject(root, "telegram_configured", config_manager_telegram_is_configured());
+        cJSON_AddBoolToObject(root, "telegram_pairing_enabled",
+                              config_manager_get_telegram_pairing_enabled());
+        cJSON_AddBoolToObject(root, "telegram_wake_notify_enabled",
+                              config_manager_get_telegram_wake_notify_enabled());
 
         // AI API Keys
         const char *openai_key = config_manager_get_openai_api_key();
@@ -1726,6 +1740,11 @@ static esp_err_t config_handler(httpd_req_t *req)
         // Other
         cJSON_AddBoolToObject(root, "deep_sleep_enabled", config_manager_get_deep_sleep_enabled());
         cJSON_AddBoolToObject(root, "debug_log_enabled", config_manager_get_debug_log_enabled());
+        cJSON_AddBoolToObject(root, "ota_check_enabled", config_manager_get_ota_check_enabled());
+        cJSON_AddBoolToObject(root, "error_overlay_enabled",
+                              config_manager_get_error_overlay_enabled());
+        cJSON_AddBoolToObject(root, "wifi_performance_mode_enabled",
+                              config_manager_get_wifi_performance_mode_enabled());
 
         char *json_str = cJSON_Print(root);
         httpd_resp_set_type(req, "application/json");

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include "album_manager.h"
+#include "battery_history.h"
 #include "board_hal.h"
 #include "cJSON.h"
 #include "color_palette.h"
@@ -1338,6 +1339,31 @@ static esp_err_t battery_handler(httpd_req_t *req)
     return ESP_OK;
 }
 
+static esp_err_t battery_history_handler(httpd_req_t *req)
+{
+    if (!system_ready) {
+        httpd_resp_set_status(req, HTTPD_503);
+        httpd_resp_sendstr(req, "System is still initializing");
+        return ESP_FAIL;
+    }
+
+    cJSON *response = battery_history_build_json();
+    if (response == NULL) {
+        httpd_resp_set_status(req, HTTPD_500);
+        httpd_resp_sendstr(req, "Failed to build battery history JSON");
+        return ESP_FAIL;
+    }
+
+    char *json_str = cJSON_Print(response);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, json_str);
+
+    free(json_str);
+    cJSON_Delete(response);
+
+    return ESP_OK;
+}
+
 static esp_err_t sensor_handler(httpd_req_t *req)
 {
     if (!system_ready) {
@@ -1747,6 +1773,8 @@ static esp_err_t config_handler(httpd_req_t *req)
                               config_manager_get_wifi_performance_mode_enabled());
         cJSON_AddBoolToObject(root, "rotation_pairing_enabled",
                               config_manager_get_rotation_pairing_enabled());
+        cJSON_AddBoolToObject(root, "telegram_rotation_notify_enabled",
+                              config_manager_get_telegram_rotation_notify_enabled());
 
         char *json_str = cJSON_Print(root);
         httpd_resp_set_type(req, "application/json");
@@ -2768,6 +2796,12 @@ esp_err_t http_server_init(void)
                                    .handler = battery_handler,
                                    .user_ctx = NULL};
         httpd_register_uri_handler(server, &battery_uri);
+
+        httpd_uri_t battery_history_uri = {.uri = "/api/battery-history",
+                                           .method = HTTP_GET,
+                                           .handler = battery_history_handler,
+                                           .user_ctx = NULL};
+        httpd_register_uri_handler(server, &battery_history_uri);
 
         httpd_uri_t sensor_uri = {
             .uri = "/api/sensor", .method = HTTP_GET, .handler = sensor_handler, .user_ctx = NULL};

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -1492,6 +1492,8 @@ static esp_err_t config_handler(httpd_req_t *req)
                               config_manager_get_rotation_pairing_enabled());
         cJSON_AddBoolToObject(root, "telegram_rotation_notify_enabled",
                               config_manager_get_telegram_rotation_notify_enabled());
+        cJSON_AddBoolToObject(root, "telegram_keep_originals_enabled",
+                              config_manager_get_telegram_keep_originals_enabled());
 
         char *json_str = cJSON_Print(root);
         httpd_resp_set_type(req, "application/json");
@@ -1853,7 +1855,7 @@ static esp_err_t album_images_handler(httpd_req_t *req)
                 // Check if a corresponding JPG-named thumbnail exists (Web UI
                 // uploads generate a real one client-side; Telegram downloads
                 // get one generated server-side - see
-                // generate_telegram_thumbnail() in telegram_bot.c - as
+                // generate_original_thumbnail() in telegram_bot.c - as
                 // PNG-encoded bytes under a ".jpg" name, since the firmware
                 // has no JPEG encoder; browsers sniff content, not
                 // extension, so this displays fine either way). Always a

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -1745,6 +1745,8 @@ static esp_err_t config_handler(httpd_req_t *req)
                               config_manager_get_error_overlay_enabled());
         cJSON_AddBoolToObject(root, "wifi_performance_mode_enabled",
                               config_manager_get_wifi_performance_mode_enabled());
+        cJSON_AddBoolToObject(root, "rotation_pairing_enabled",
+                              config_manager_get_rotation_pairing_enabled());
 
         char *json_str = cJSON_Print(root);
         httpd_resp_set_type(req, "application/json");
@@ -2056,9 +2058,15 @@ static esp_err_t album_images_handler(httpd_req_t *req)
 
     char query[256];
     char album_name[128] = "";
+    bool include_thumbnails = true;
 
     if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
         httpd_query_key_value(query, "album", album_name, sizeof(album_name));
+        char thumbnails_param[8] = "";
+        if (httpd_query_key_value(query, "thumbnails", thumbnails_param,
+                                  sizeof(thumbnails_param)) == ESP_OK) {
+            include_thumbnails = (strcmp(thumbnails_param, "0") != 0);
+        }
     }
 
     if (strlen(album_name) == 0) {
@@ -2097,21 +2105,33 @@ static esp_err_t album_images_handler(httpd_req_t *req)
                 cJSON_AddStringToObject(image_obj, "filename", entry->d_name);
                 cJSON_AddStringToObject(image_obj, "album", decoded_album_name);
 
-                // Check if a corresponding JPG thumbnail exists for any image type
-                char thumbnail_name[256];
-                char thumbnail_path[512];
+                // Check if a corresponding JPG-named thumbnail exists (Web UI
+                // uploads generate a real one client-side; Telegram downloads
+                // get one generated server-side - see
+                // generate_telegram_thumbnail() in telegram_bot.c - as
+                // PNG-encoded bytes under a ".jpg" name, since the firmware
+                // has no JPEG encoder; browsers sniff content, not
+                // extension, so this displays fine either way). Always a
+                // different filename than the main image itself, since a
+                // ".jpg" thumbnail can never collide with a listed
+                // .bmp/.png/.epdgz main image. Skipped entirely when the
+                // client doesn't want thumbnails (Web UI "Show thumbnails"
+                // off) - the per-file stat() here was adding measurable
+                // list-load latency for no benefit in that case.
+                if (include_thumbnails) {
+                    char thumbnail_name[256];
+                    char thumbnail_path[512];
 
-                // Extract base name without extension
-                int base_len = ext - entry->d_name;
-                snprintf(thumbnail_name, sizeof(thumbnail_name), "%.*s.jpg", base_len,
-                         entry->d_name);
-                snprintf(thumbnail_path, sizeof(thumbnail_path), "%s/%s", album_path,
-                         thumbnail_name);
+                    int base_len = ext - entry->d_name;
+                    snprintf(thumbnail_name, sizeof(thumbnail_name), "%.*s.jpg", base_len,
+                             entry->d_name);
+                    snprintf(thumbnail_path, sizeof(thumbnail_path), "%s/%s", album_path,
+                             thumbnail_name);
 
-                // Check if thumbnail file exists
-                struct stat st;
-                if (stat(thumbnail_path, &st) == 0) {
-                    cJSON_AddStringToObject(image_obj, "thumbnail", thumbnail_name);
+                    struct stat st;
+                    if (stat(thumbnail_path, &st) == 0) {
+                        cJSON_AddStringToObject(image_obj, "thumbnail", thumbnail_name);
+                    }
                 }
 
                 cJSON_AddItemToArray(response, image_obj);
@@ -2368,6 +2388,23 @@ static esp_err_t display_calibration_handler(httpd_req_t *req)
         httpd_resp_set_type(req, "application/json");
         httpd_resp_sendstr(
             req, "{\"status\":\"error\",\"message\":\"Failed to display calibration pattern\"}");
+        return ESP_FAIL;
+    }
+}
+
+static esp_err_t error_overlay_test_handler(httpd_req_t *req)
+{
+    ESP_LOGI(TAG, "Testing error overlay display");
+
+    esp_err_t ret = utils_test_error_overlay();
+
+    httpd_resp_set_type(req, "application/json");
+    if (ret == ESP_OK) {
+        httpd_resp_sendstr(req, "{\"status\":\"success\",\"message\":\"Error overlay displayed\"}");
+        return ESP_OK;
+    } else {
+        httpd_resp_set_status(req, "500 Internal Server Error");
+        httpd_resp_sendstr(req, "{\"status\":\"error\",\"message\":\"Failed to display error overlay\"}");
         return ESP_FAIL;
     }
 }
@@ -2889,6 +2926,12 @@ esp_err_t http_server_init(void)
                                                .handler = display_calibration_handler,
                                                .user_ctx = NULL};
         httpd_register_uri_handler(server, &display_calibration_uri);
+
+        httpd_uri_t error_overlay_test_uri = {.uri = "/api/error-overlay/test",
+                                              .method = HTTP_POST,
+                                              .handler = error_overlay_test_handler,
+                                              .user_ctx = NULL};
+        httpd_register_uri_handler(server, &error_overlay_test_uri);
 
         ESP_LOGI(TAG, "HTTP server started");
         return ESP_OK;

--- a/main/image_processor.c
+++ b/main/image_processor.c
@@ -2533,16 +2533,11 @@ esp_err_t image_processor_write_rgb_to_png(const uint8_t *rgb_buffer, int width,
     return write_png_file(output_path, (uint8_t *) rgb_buffer, width, height);
 }
 
-esp_err_t image_processor_make_thumbnail(const char *source_png_path, int max_dimension,
-                                         const char *output_path)
+static esp_err_t read_file_into_buffer(const char *path, uint8_t **out_data, long *out_size)
 {
-    if (!source_png_path || !output_path || max_dimension <= 0) {
-        return ESP_ERR_INVALID_ARG;
-    }
-
-    FILE *fp = fopen(source_png_path, "rb");
+    FILE *fp = fopen(path, "rb");
     if (!fp) {
-        ESP_LOGE(TAG, "Failed to open %s for thumbnail generation", source_png_path);
+        ESP_LOGE(TAG, "Failed to open %s", path);
         return ESP_FAIL;
     }
     fseek(fp, 0, SEEK_END);
@@ -2553,26 +2548,29 @@ esp_err_t image_processor_make_thumbnail(const char *source_png_path, int max_di
         return ESP_FAIL;
     }
 
-    uint8_t *file_buffer = (uint8_t *) heap_caps_malloc(file_size, MALLOC_CAP_SPIRAM);
-    if (!file_buffer) {
+    uint8_t *buf = (uint8_t *) heap_caps_malloc((size_t) file_size, MALLOC_CAP_SPIRAM);
+    if (!buf) {
         fclose(fp);
         return ESP_ERR_NO_MEM;
     }
-    size_t read_bytes = fread(file_buffer, 1, file_size, fp);
+    size_t read_bytes = fread(buf, 1, (size_t) file_size, fp);
     fclose(fp);
     if (read_bytes != (size_t) file_size) {
-        heap_caps_free(file_buffer);
+        heap_caps_free(buf);
         return ESP_FAIL;
     }
+    *out_data = buf;
+    *out_size = file_size;
+    return ESP_OK;
+}
 
-    uint8_t *src_rgb = NULL;
-    int src_width = 0, src_height = 0;
-    esp_err_t err = decode_png_buffer(file_buffer, file_size, &src_rgb, &src_width, &src_height);
-    heap_caps_free(file_buffer);
-    if (err != ESP_OK) {
-        return err;
-    }
-
+// Nearest-neighbor downsample of a decoded RGB888 buffer, written out as a
+// PNG - a grid/chat preview doesn't need anything fancier, and this keeps
+// the extra CPU/RAM cost minimal. Shared by both thumbnail entry points
+// below; frees neither buffer.
+static esp_err_t make_thumbnail_from_rgb(const uint8_t *src_rgb, int src_width, int src_height,
+                                         int max_dimension, const char *output_path)
+{
     int dst_width, dst_height;
     if (src_width >= src_height) {
         dst_width = max_dimension;
@@ -2591,12 +2589,9 @@ esp_err_t image_processor_make_thumbnail(const char *source_png_path, int max_di
     uint8_t *dst_rgb =
         (uint8_t *) heap_caps_malloc((size_t) dst_width * dst_height * 3, MALLOC_CAP_SPIRAM);
     if (!dst_rgb) {
-        heap_caps_free(src_rgb);
         return ESP_ERR_NO_MEM;
     }
 
-    // Nearest-neighbor downsample - a grid preview doesn't need anything
-    // fancier, and this keeps the extra CPU/RAM cost minimal.
     for (int y = 0; y < dst_height; y++) {
         int src_y = (int) ((int64_t) y * src_height / dst_height);
         for (int x = 0; x < dst_width; x++) {
@@ -2608,9 +2603,68 @@ esp_err_t image_processor_make_thumbnail(const char *source_png_path, int max_di
             dp[2] = sp[2];
         }
     }
-    heap_caps_free(src_rgb);
 
-    err = write_png_file(output_path, dst_rgb, dst_width, dst_height);
+    esp_err_t err = write_png_file(output_path, dst_rgb, dst_width, dst_height);
     heap_caps_free(dst_rgb);
+    return err;
+}
+
+esp_err_t image_processor_make_thumbnail(const char *source_png_path, int max_dimension,
+                                         const char *output_path)
+{
+    if (!source_png_path || !output_path || max_dimension <= 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    uint8_t *file_buffer = NULL;
+    long file_size = 0;
+    esp_err_t err = read_file_into_buffer(source_png_path, &file_buffer, &file_size);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    uint8_t *src_rgb = NULL;
+    int src_width = 0, src_height = 0;
+    err = decode_png_buffer(file_buffer, file_size, &src_rgb, &src_width, &src_height);
+    heap_caps_free(file_buffer);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = make_thumbnail_from_rgb(src_rgb, src_width, src_height, max_dimension, output_path);
+    heap_caps_free(src_rgb);
+    return err;
+}
+
+esp_err_t image_processor_make_thumbnail_from_original(const char *source_path,
+                                                        image_format_t format, int max_dimension,
+                                                        const char *output_path)
+{
+    if (!source_path || !output_path || max_dimension <= 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (format != IMAGE_FORMAT_JPG && format != IMAGE_FORMAT_PNG) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    uint8_t *file_buffer = NULL;
+    long file_size = 0;
+    esp_err_t err = read_file_into_buffer(source_path, &file_buffer, &file_size);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    uint8_t *src_rgb = NULL;
+    int src_width = 0, src_height = 0;
+    err = (format == IMAGE_FORMAT_JPG)
+             ? decode_jpg_buffer(file_buffer, file_size, &src_rgb, &src_width, &src_height)
+             : decode_png_buffer(file_buffer, file_size, &src_rgb, &src_width, &src_height);
+    heap_caps_free(file_buffer);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = make_thumbnail_from_rgb(src_rgb, src_width, src_height, max_dimension, output_path);
+    heap_caps_free(src_rgb);
     return err;
 }

--- a/main/image_processor.c
+++ b/main/image_processor.c
@@ -910,6 +910,30 @@ static esp_err_t png_writer_close(png_writer_t *pw, bool success)
     return err;
 }
 
+// Writes a whole in-RAM RGB888 buffer to a PNG file in one call, for callers
+// that already have a complete buffer (Telegram pairing/thumbnail/caption
+// helpers) rather than a row-by-row source - built on the same png_writer_t
+// streaming primitives as the rest of this file, just driven in a loop
+// instead of from a decode callback.
+static esp_err_t write_png_file(const char *filename, uint8_t *rgb_data, int width, int height)
+{
+    png_writer_t pw;
+    esp_err_t err = png_writer_open(&pw, filename, width, height);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    bool ok = true;
+    for (int y = 0; y < height; y++) {
+        if (png_writer_row_sink(&pw, y, &rgb_data[(size_t) y * width * 3]) != ESP_OK) {
+            ok = false;
+            break;
+        }
+    }
+
+    return png_writer_close(&pw, ok);
+}
+
 // Decode JPG from buffer to RGB
 static esp_err_t decode_jpg_buffer(const uint8_t *jpg_data, size_t jpg_size, uint8_t **rgb_buffer,
                                    int *width, int *height)
@@ -1816,6 +1840,118 @@ esp_err_t image_processor_peek_dimensions(const uint8_t *data, size_t size, imag
     return ESP_ERR_NOT_SUPPORTED;
 }
 
+bool image_processor_is_processed(const char *input_path)
+{
+    ESP_LOGD(TAG, "Checking if image is already processed: %s", input_path);
+
+    FILE *fp = fopen(input_path, "rb");
+    if (!fp) {
+        ESP_LOGE(TAG, "Failed to open input file: %s", input_path);
+        return false;
+    }
+
+    uint8_t sig[8];
+    size_t read = fread(sig, 1, 8, fp);
+    if (read != 8 || png_sig_cmp(sig, 0, 8) != 0) {
+        ESP_LOGD(TAG, "Not a PNG file");
+        fclose(fp);
+        return false;
+    }
+
+    png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    if (!png_ptr) {
+        fclose(fp);
+        return false;
+    }
+
+    png_infop info_ptr = png_create_info_struct(png_ptr);
+    if (!info_ptr) {
+        png_destroy_read_struct(&png_ptr, NULL, NULL);
+        fclose(fp);
+        return false;
+    }
+
+    if (setjmp(png_jmpbuf(png_ptr))) {
+        ESP_LOGE(TAG, "PNG error during check");
+        png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+        fclose(fp);
+        return false;
+    }
+
+    png_init_io(png_ptr, fp);
+    png_set_sig_bytes(png_ptr, 8);
+    png_read_info(png_ptr, info_ptr);
+
+    int width = png_get_image_width(png_ptr, info_ptr);
+    int height = png_get_image_height(png_ptr, info_ptr);
+
+    if (width != BOARD_HAL_DISPLAY_WIDTH || height != BOARD_HAL_DISPLAY_HEIGHT) {
+        ESP_LOGI(TAG, "Dimensions mismatch: %dx%d (expected %dx%d)", width, height,
+                 BOARD_HAL_DISPLAY_WIDTH, BOARD_HAL_DISPLAY_HEIGHT);
+        png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+        fclose(fp);
+        return false;
+    }
+
+    // Force RGB format
+    png_set_expand(png_ptr);
+    png_set_strip_alpha(png_ptr);
+    png_set_packing(png_ptr);
+    png_set_palette_to_rgb(png_ptr);
+    png_read_update_info(png_ptr, info_ptr);
+
+    if (png_get_channels(png_ptr, info_ptr) != 3) {
+        ESP_LOGI(TAG, "Not RGB format");
+        png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+        fclose(fp);
+        return false;
+    }
+
+    // Check pixels row by row against the fixed theoretical palette (see
+    // the header doc comment for why not the calibrated/measured one).
+    png_bytep row = (png_bytep) malloc(png_get_rowbytes(png_ptr, info_ptr));
+    if (!row) {
+        ESP_LOGE(TAG, "Failed to allocate row buffer");
+        png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+        fclose(fp);
+        return false;
+    }
+
+    bool valid = true;
+    for (int y = 0; y < height; y++) {
+        png_read_row(png_ptr, row, NULL);
+
+        for (int x = 0; x < width; x++) {
+            uint8_t r = row[x * 3];
+            uint8_t g = row[x * 3 + 1];
+            uint8_t b = row[x * 3 + 2];
+
+            bool color_match = false;
+            for (int i = 0; i < 7; i++) {
+                if (i == 4)
+                    continue;  // Skip reserved
+                if (r == palette[i].r && g == palette[i].g && b == palette[i].b) {
+                    color_match = true;
+                    break;
+                }
+            }
+
+            if (!color_match) {
+                valid = false;
+                break;
+            }
+        }
+        if (!valid) {
+            break;
+        }
+    }
+
+    free(row);
+    png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    fclose(fp);
+    return valid;
+}
+
 esp_err_t image_processor_peek_file_dimensions(const char *path, image_format_t format, int *out_w,
                                                int *out_h)
 {
@@ -1839,6 +1975,180 @@ esp_err_t image_processor_peek_file_dimensions(const char *path, image_format_t 
     esp_err_t err = image_processor_peek_dimensions(buf, n, format, out_w, out_h);
     free(buf);
     return err;
+}
+
+// Nearest-neighbor "cover" resize (scale to fill dst, crop excess, centered)
+// of a whole in-RAM RGB888 buffer. Only used by image_processor_compose_pair_to_rgb() below -
+// everything else in this file resizes as part of the row-streaming pipeline instead.
+static uint8_t *resize_image(uint8_t *src, int src_w, int src_h, int dst_w, int dst_h)
+{
+    uint8_t *dst = (uint8_t *) heap_caps_malloc((size_t) dst_w * dst_h * 3, MALLOC_CAP_SPIRAM);
+    if (!dst) {
+        ESP_LOGE(TAG, "Failed to allocate resize buffer");
+        return NULL;
+    }
+
+    float scale_x = (float) dst_w / src_w;
+    float scale_y = (float) dst_h / src_h;
+    float scale = fmaxf(scale_x, scale_y);
+
+    int scaled_w = (int) (src_w * scale);
+    int scaled_h = (int) (src_h * scale);
+
+    int offset_x = (scaled_w - dst_w) / 2;
+    int offset_y = (scaled_h - dst_h) / 2;
+
+    for (int y = 0; y < dst_h; y++) {
+        for (int x = 0; x < dst_w; x++) {
+            float scaled_x = x + offset_x;
+            float scaled_y = y + offset_y;
+
+            float src_x_f = scaled_x / scale;
+            float src_y_f = scaled_y / scale;
+
+            int src_x = (int) src_x_f;
+            int src_y = (int) src_y_f;
+
+            if (src_x >= src_w)
+                src_x = src_w - 1;
+            if (src_y >= src_h)
+                src_y = src_h - 1;
+            if (src_x < 0)
+                src_x = 0;
+            if (src_y < 0)
+                src_y = 0;
+
+            int dst_idx = (y * dst_w + x) * 3;
+            int src_idx = (src_y * src_w + src_x) * 3;
+
+            dst[dst_idx] = src[src_idx];
+            dst[dst_idx + 1] = src[src_idx + 1];
+            dst[dst_idx + 2] = src[src_idx + 2];
+        }
+    }
+
+    return dst;
+}
+
+// Resize/rotate-to-fit a whole in-RAM RGB888 buffer to the panel's native
+// resolution, then apply CDR + dithering - the same per-row primitives
+// (cdr_apply_row / dither_row) the main row-streaming pipeline uses, just
+// driven in a loop here since the caller already has a complete buffer
+// rather than a row source. Keeps composed-pair/thumbnail output visually
+// consistent with every other image the device displays, using the same
+// measured-palette calibration.
+static esp_err_t process_rgb_buffer_core(uint8_t *rgb_buffer, int width, int height,
+                                         dither_algorithm_t dither_algorithm, uint8_t **out_buffer,
+                                         int *out_width, int *out_height)
+{
+    ESP_LOGI(TAG, "Processing RGB buffer: %dx%d", width, height);
+
+    uint8_t *resized = NULL;
+    uint8_t *rotated = NULL;
+    uint8_t *final_image = rgb_buffer;
+    int final_width = width;
+    int final_height = height;
+
+    bool image_is_portrait = height > width;
+    bool board_is_portrait = BOARD_HAL_DISPLAY_HEIGHT > BOARD_HAL_DISPLAY_WIDTH;
+    bool needs_rotation = image_is_portrait != board_is_portrait;
+
+    // STEP 1: Resize for target orientation
+    int target_width, target_height;
+    if (needs_rotation) {
+        target_width = (width * BOARD_HAL_DISPLAY_WIDTH) / height;
+        target_height = BOARD_HAL_DISPLAY_WIDTH;
+    } else {
+        target_width = BOARD_HAL_DISPLAY_WIDTH;
+        target_height = BOARD_HAL_DISPLAY_HEIGHT;
+    }
+
+    if (final_width != target_width || final_height != target_height) {
+        ESP_LOGI(TAG, "Resizing image to %dx%d", target_width, target_height);
+        resized = resize_image(final_image, final_width, final_height, target_width, target_height);
+        if (!resized) {
+            ESP_LOGE(TAG, "Failed to resize image to %dx%d", target_width, target_height);
+            return ESP_FAIL;
+        }
+        if (final_image != rgb_buffer)
+            heap_caps_free(final_image);
+        final_image = resized;
+        final_width = target_width;
+        final_height = target_height;
+    }
+
+    // STEP 2: Rotate
+    if (needs_rotation) {
+        ESP_LOGI(TAG, "Rotating image by 90 degrees");
+        size_t rotated_size = (size_t) final_width * final_height * 3;
+        rotated = (uint8_t *) heap_caps_malloc(rotated_size, MALLOC_CAP_SPIRAM);
+        if (!rotated) {
+            ESP_LOGE(TAG, "Failed to allocate rotation buffer of %zu bytes", rotated_size);
+            if (final_image != rgb_buffer)
+                heap_caps_free(final_image);
+            return ESP_FAIL;
+        }
+
+        for (int y = 0; y < final_height; y++) {
+            for (int x = 0; x < final_width; x++) {
+                int src_idx = (y * final_width + x) * 3;
+                int dst_x = final_height - 1 - y;
+                int dst_y = x;
+                int dst_idx = (dst_y * final_height + dst_x) * 3;
+                rotated[dst_idx] = final_image[src_idx];
+                rotated[dst_idx + 1] = final_image[src_idx + 1];
+                rotated[dst_idx + 2] = final_image[src_idx + 2];
+            }
+        }
+        if (final_image != rgb_buffer)
+            heap_caps_free(final_image);
+        final_image = rotated;
+        int temp = final_width;
+        final_width = final_height;
+        final_height = temp;
+    }
+
+    // STEP 3: Final fit check
+    if (final_width != BOARD_HAL_DISPLAY_WIDTH || final_height != BOARD_HAL_DISPLAY_HEIGHT) {
+        uint8_t *final_resized = resize_image(final_image, final_width, final_height,
+                                              BOARD_HAL_DISPLAY_WIDTH, BOARD_HAL_DISPLAY_HEIGHT);
+        if (!final_resized) {
+            ESP_LOGE(TAG, "Failed to final resize image to %dx%d", BOARD_HAL_DISPLAY_WIDTH,
+                     BOARD_HAL_DISPLAY_HEIGHT);
+            if (final_image != rgb_buffer)
+                heap_caps_free(final_image);
+            return ESP_FAIL;
+        }
+        if (final_image != rgb_buffer)
+            heap_caps_free(final_image);
+        final_image = final_resized;
+        final_width = BOARD_HAL_DISPLAY_WIDTH;
+        final_height = BOARD_HAL_DISPLAY_HEIGHT;
+    }
+
+    // Apply fast CDR + dithering, row by row, via the shared engine.
+    cdr_state_t cdr;
+    cdr_init(&cdr);
+
+    dither_state_t dither_st;
+    esp_err_t derr = dither_init(&dither_st, final_width, dither_algorithm);
+    if (derr != ESP_OK) {
+        if (final_image != rgb_buffer)
+            heap_caps_free(final_image);
+        return derr;
+    }
+
+    for (int y = 0; y < final_height; y++) {
+        uint8_t *row = &final_image[(size_t) y * final_width * 3];
+        cdr_apply_row(&cdr, row, final_width);
+        dither_row(&dither_st, row);
+    }
+    dither_free(&dither_st);
+
+    *out_buffer = final_image;
+    *out_width = final_width;
+    *out_height = final_height;
+    return ESP_OK;
 }
 
 esp_err_t image_processor_compose_pair_to_rgb(const uint8_t *data_a, size_t size_a,

--- a/main/image_processor.c
+++ b/main/image_processor.c
@@ -1107,6 +1107,31 @@ esp_err_t image_processor_peek_dimensions(const uint8_t *data, size_t size, imag
     return ESP_ERR_NOT_SUPPORTED;
 }
 
+esp_err_t image_processor_peek_file_dimensions(const char *path, image_format_t format, int *out_w,
+                                               int *out_h)
+{
+    if (!path) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        return ESP_FAIL;
+    }
+    // Header-only peek - large enough for both JPEG SOF markers and a PNG
+    // IHDR chunk without reading the whole (possibly multi-MB) file.
+    const size_t scan_bytes = 65536;
+    uint8_t *buf = malloc(scan_bytes);
+    if (!buf) {
+        fclose(f);
+        return ESP_ERR_NO_MEM;
+    }
+    size_t n = fread(buf, 1, scan_bytes, f);
+    fclose(f);
+    esp_err_t err = image_processor_peek_dimensions(buf, n, format, out_w, out_h);
+    free(buf);
+    return err;
+}
+
 esp_err_t image_processor_compose_pair_to_rgb(const uint8_t *data_a, size_t size_a,
                                               image_format_t format_a, const uint8_t *data_b,
                                               size_t size_b, image_format_t format_b,
@@ -1487,4 +1512,86 @@ esp_err_t image_processor_write_rgb_to_png(const uint8_t *rgb_buffer, int width,
         return ESP_ERR_INVALID_ARG;
     }
     return write_png_file(output_path, (uint8_t *) rgb_buffer, width, height);
+}
+
+esp_err_t image_processor_make_thumbnail(const char *source_png_path, int max_dimension,
+                                         const char *output_path)
+{
+    if (!source_png_path || !output_path || max_dimension <= 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    FILE *fp = fopen(source_png_path, "rb");
+    if (!fp) {
+        ESP_LOGE(TAG, "Failed to open %s for thumbnail generation", source_png_path);
+        return ESP_FAIL;
+    }
+    fseek(fp, 0, SEEK_END);
+    long file_size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    if (file_size <= 0) {
+        fclose(fp);
+        return ESP_FAIL;
+    }
+
+    uint8_t *file_buffer = (uint8_t *) heap_caps_malloc(file_size, MALLOC_CAP_SPIRAM);
+    if (!file_buffer) {
+        fclose(fp);
+        return ESP_ERR_NO_MEM;
+    }
+    size_t read_bytes = fread(file_buffer, 1, file_size, fp);
+    fclose(fp);
+    if (read_bytes != (size_t) file_size) {
+        heap_caps_free(file_buffer);
+        return ESP_FAIL;
+    }
+
+    uint8_t *src_rgb = NULL;
+    int src_width = 0, src_height = 0;
+    esp_err_t err = decode_png_buffer(file_buffer, file_size, &src_rgb, &src_width, &src_height);
+    heap_caps_free(file_buffer);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    int dst_width, dst_height;
+    if (src_width >= src_height) {
+        dst_width = max_dimension;
+        dst_height = (int) ((int64_t) src_height * max_dimension / src_width);
+    } else {
+        dst_height = max_dimension;
+        dst_width = (int) ((int64_t) src_width * max_dimension / src_height);
+    }
+    if (dst_width < 1) {
+        dst_width = 1;
+    }
+    if (dst_height < 1) {
+        dst_height = 1;
+    }
+
+    uint8_t *dst_rgb =
+        (uint8_t *) heap_caps_malloc((size_t) dst_width * dst_height * 3, MALLOC_CAP_SPIRAM);
+    if (!dst_rgb) {
+        heap_caps_free(src_rgb);
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Nearest-neighbor downsample - a grid preview doesn't need anything
+    // fancier, and this keeps the extra CPU/RAM cost minimal.
+    for (int y = 0; y < dst_height; y++) {
+        int src_y = (int) ((int64_t) y * src_height / dst_height);
+        for (int x = 0; x < dst_width; x++) {
+            int src_x = (int) ((int64_t) x * src_width / dst_width);
+            const uint8_t *sp = &src_rgb[(size_t) (src_y * src_width + src_x) * 3];
+            uint8_t *dp = &dst_rgb[(size_t) (y * dst_width + x) * 3];
+            dp[0] = sp[0];
+            dp[1] = sp[1];
+            dp[2] = sp[2];
+        }
+    }
+    heap_caps_free(src_rgb);
+
+    err = write_png_file(output_path, dst_rgb, dst_width, dst_height);
+    heap_caps_free(dst_rgb);
+    return err;
 }

--- a/main/image_processor.c
+++ b/main/image_processor.c
@@ -13,6 +13,7 @@
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_task_wdt.h"
+#include "fonts.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "jpeg_decoder.h"
@@ -1053,4 +1054,437 @@ image_format_t image_processor_detect_format(const char *input_path)
     }
 
     return IMAGE_FORMAT_UNKNOWN;
+}
+
+esp_err_t image_processor_peek_dimensions(const uint8_t *data, size_t size, image_format_t format,
+                                          int *out_width, int *out_height)
+{
+    if (!data || size == 0 || !out_width || !out_height) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (format == IMAGE_FORMAT_JPG) {
+        esp_jpeg_image_cfg_t jpeg_cfg = {.indata = (uint8_t *) data,
+                                         .indata_size = size,
+                                         .out_format = JPEG_IMAGE_FORMAT_RGB888,
+                                         .out_scale = JPEG_IMAGE_SCALE_0};
+        esp_jpeg_image_output_t outimg;
+        esp_err_t err = esp_jpeg_get_image_info(&jpeg_cfg, &outimg);
+        if (err != ESP_OK) {
+            return err;
+        }
+        *out_width = outimg.width;
+        *out_height = outimg.height;
+        return ESP_OK;
+    }
+
+    if (format == IMAGE_FORMAT_PNG) {
+        png_mem_read_t mem = {.data = data, .size = size, .offset = 0};
+
+        png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+        if (!png_ptr) {
+            return ESP_FAIL;
+        }
+        png_infop info_ptr = png_create_info_struct(png_ptr);
+        if (!info_ptr) {
+            png_destroy_read_struct(&png_ptr, NULL, NULL);
+            return ESP_FAIL;
+        }
+        if (setjmp(png_jmpbuf(png_ptr))) {
+            png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+            return ESP_FAIL;
+        }
+
+        png_set_read_fn(png_ptr, &mem, png_mem_read_callback);
+        png_read_info(png_ptr, info_ptr);
+        *out_width = png_get_image_width(png_ptr, info_ptr);
+        *out_height = png_get_image_height(png_ptr, info_ptr);
+
+        png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+        return ESP_OK;
+    }
+
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+esp_err_t image_processor_compose_pair_to_rgb(const uint8_t *data_a, size_t size_a,
+                                              image_format_t format_a, const uint8_t *data_b,
+                                              size_t size_b, image_format_t format_b,
+                                              bool stack_vertically,
+                                              dither_algorithm_t dither_algorithm,
+                                              image_process_rgb_result_t *result)
+{
+    if (!data_a || !data_b || !result) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    memset(result, 0, sizeof(*result));
+
+    uint8_t *rgb_a = NULL, *rgb_b = NULL;
+    int wa = 0, ha = 0, wb = 0, hb = 0;
+    esp_err_t err;
+
+    if (format_a == IMAGE_FORMAT_JPG) {
+        err = decode_jpg_buffer(data_a, size_a, &rgb_a, &wa, &ha);
+    } else if (format_a == IMAGE_FORMAT_PNG) {
+        err = decode_png_buffer(data_a, size_a, &rgb_a, &wa, &ha);
+    } else {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (format_b == IMAGE_FORMAT_JPG) {
+        err = decode_jpg_buffer(data_b, size_b, &rgb_b, &wb, &hb);
+    } else if (format_b == IMAGE_FORMAT_PNG) {
+        err = decode_png_buffer(data_b, size_b, &rgb_b, &wb, &hb);
+    } else {
+        heap_caps_free(rgb_a);
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    if (err != ESP_OK) {
+        heap_caps_free(rgb_a);
+        return err;
+    }
+
+    int half_w = stack_vertically ? BOARD_HAL_DISPLAY_WIDTH : BOARD_HAL_DISPLAY_WIDTH / 2;
+    int half_h = stack_vertically ? BOARD_HAL_DISPLAY_HEIGHT / 2 : BOARD_HAL_DISPLAY_HEIGHT;
+
+    uint8_t *resized_a = resize_image(rgb_a, wa, ha, half_w, half_h);
+    heap_caps_free(rgb_a);
+    uint8_t *resized_b = resize_image(rgb_b, wb, hb, half_w, half_h);
+    heap_caps_free(rgb_b);
+
+    if (!resized_a || !resized_b) {
+        ESP_LOGE(TAG, "Failed to resize one or both images for pair composition");
+        if (resized_a)
+            heap_caps_free(resized_a);
+        if (resized_b)
+            heap_caps_free(resized_b);
+        return ESP_ERR_NO_MEM;
+    }
+
+    uint8_t *canvas = (uint8_t *) heap_caps_malloc(
+        (size_t) BOARD_HAL_DISPLAY_WIDTH * BOARD_HAL_DISPLAY_HEIGHT * 3, MALLOC_CAP_SPIRAM);
+    if (!canvas) {
+        ESP_LOGE(TAG, "Failed to allocate pair composition canvas");
+        heap_caps_free(resized_a);
+        heap_caps_free(resized_b);
+        return ESP_ERR_NO_MEM;
+    }
+
+    int b_off_x = stack_vertically ? 0 : half_w;
+    int b_off_y = stack_vertically ? half_h : 0;
+
+    for (int y = 0; y < half_h; y++) {
+        memcpy(&canvas[(y * BOARD_HAL_DISPLAY_WIDTH) * 3], &resized_a[y * half_w * 3],
+               (size_t) half_w * 3);
+        memcpy(&canvas[((b_off_y + y) * BOARD_HAL_DISPLAY_WIDTH + b_off_x) * 3],
+               &resized_b[y * half_w * 3], (size_t) half_w * 3);
+    }
+
+    heap_caps_free(resized_a);
+    heap_caps_free(resized_b);
+
+    ESP_LOGI(TAG, "Composed %dx%d pair canvas (%s)", BOARD_HAL_DISPLAY_WIDTH,
+             BOARD_HAL_DISPLAY_HEIGHT, stack_vertically ? "stacked" : "side-by-side");
+
+    uint8_t *processed = NULL;
+    int out_w = 0, out_h = 0;
+    err = process_rgb_buffer_core(canvas, BOARD_HAL_DISPLAY_WIDTH, BOARD_HAL_DISPLAY_HEIGHT,
+                                  dither_algorithm, &processed, &out_w, &out_h);
+    if (canvas != processed) {
+        heap_caps_free(canvas);
+    }
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    result->rgb_data = processed;
+    result->rgb_size = (size_t) out_w * out_h * 3;
+    result->width = out_w;
+    result->height = out_h;
+    return ESP_OK;
+}
+
+// Blits one glyph from the fixed-width Font24 bitmap font (1bpp, MSB-first,
+// rows packed to ceil(Width/8) bytes) onto an RGB888 buffer.
+static void draw_glyph(uint8_t *rgb, int width, int height, int x, int y, char c, rgb_t color)
+{
+    if (c < ' ' || (unsigned char) c > 0x7E) {
+        return;  // outside the printable ASCII range covered by Font24
+    }
+
+    uint32_t bytes_per_row = Font24.Width / 8 + (Font24.Width % 8 ? 1 : 0);
+    uint32_t char_offset = (uint32_t) (c - ' ') * Font24.Height * bytes_per_row;
+    const uint8_t *ptr = &Font24.table[char_offset];
+
+    for (int row = 0; row < Font24.Height; row++) {
+        for (int col = 0; col < Font24.Width; col++) {
+            if (ptr[col / 8] & (0x80 >> (col % 8))) {
+                int px = x + col, py = y + row;
+                if (px >= 0 && px < width && py >= 0 && py < height) {
+                    int idx = (py * width + px) * 3;
+                    rgb[idx] = color.r;
+                    rgb[idx + 1] = color.g;
+                    rgb[idx + 2] = color.b;
+                }
+            }
+        }
+        ptr += bytes_per_row;
+    }
+}
+
+#define CAPTION_MAX_LINES 3
+#define CAPTION_LINE_MAX_CHARS 96
+#define CAPTION_LINE_PADDING 4
+
+// Telegram captions are UTF-8; Font24 only has bitmap glyphs for ASCII
+// (space..~). Transliterate the German umlauts/sz-ligature to ASCII digraphs
+// (still legible) and silently drop every other non-ASCII code point (emoji,
+// other accents, ...) - not worth carrying a Unicode-capable bitmap font for.
+static void sanitize_caption_ascii(const char *utf8, char *out, size_t out_len)
+{
+    size_t o = 0;
+    const unsigned char *p = (const unsigned char *) utf8;
+
+    while (*p != '\0' && o + 1 < out_len) {
+        unsigned char b0 = p[0];
+
+        if (b0 < 0x80) {
+            out[o++] = (char) b0;
+            p++;
+            continue;
+        }
+
+        uint32_t cp = 0;
+        int extra;
+        if ((b0 & 0xE0) == 0xC0) {
+            cp = b0 & 0x1F;
+            extra = 1;
+        } else if ((b0 & 0xF0) == 0xE0) {
+            cp = b0 & 0x0F;
+            extra = 2;
+        } else if ((b0 & 0xF8) == 0xF0) {
+            cp = b0 & 0x07;
+            extra = 3;
+        } else {
+            p++;  // stray continuation/invalid byte, skip
+            continue;
+        }
+
+        bool valid = true;
+        for (int i = 0; i < extra; i++) {
+            unsigned char cb = p[1 + i];
+            if ((cb & 0xC0) != 0x80) {
+                valid = false;
+                break;
+            }
+            cp = (cp << 6) | (cb & 0x3F);
+        }
+        if (!valid) {
+            p++;
+            continue;
+        }
+        p += 1 + extra;
+
+        const char *sub = NULL;
+        switch (cp) {
+        case 0x00E4:
+            sub = "ae";
+            break;  // ä
+        case 0x00F6:
+            sub = "oe";
+            break;  // ö
+        case 0x00FC:
+            sub = "ue";
+            break;  // ü
+        case 0x00C4:
+            sub = "Ae";
+            break;  // Ä
+        case 0x00D6:
+            sub = "Oe";
+            break;  // Ö
+        case 0x00DC:
+            sub = "Ue";
+            break;  // Ü
+        case 0x00DF:
+            sub = "ss";
+            break;  // ß
+        default:
+            break;  // everything else (accents, emoji, symbols, ...) dropped
+        }
+        for (const char *s = sub; s && *s != '\0' && o + 1 < out_len; s++) {
+            out[o++] = *s;
+        }
+    }
+    out[o] = '\0';
+}
+
+void image_processor_draw_caption(uint8_t *rgb_buffer, int width, int height, const char *caption)
+{
+    if (!rgb_buffer || !caption || caption[0] == '\0') {
+        return;
+    }
+
+    char ascii_caption[CAPTION_LINE_MAX_CHARS * CAPTION_MAX_LINES];
+    sanitize_caption_ascii(caption, ascii_caption, sizeof(ascii_caption));
+    if (ascii_caption[0] == '\0') {
+        return;  // nothing renderable left (e.g. an emoji-only caption)
+    }
+    caption = ascii_caption;
+
+    int chars_per_line = (width - 2 * CAPTION_LINE_PADDING) / Font24.Width;
+    if (chars_per_line < 1) {
+        return;  // display too narrow for this font, skip silently
+    }
+    if (chars_per_line > CAPTION_LINE_MAX_CHARS - 1) {
+        chars_per_line = CAPTION_LINE_MAX_CHARS - 1;
+    }
+
+    // Greedy word-wrap into up to CAPTION_MAX_LINES lines.
+    char lines[CAPTION_MAX_LINES][CAPTION_LINE_MAX_CHARS];
+    int line_count = 0;
+    char current[CAPTION_LINE_MAX_CHARS] = {0};
+    size_t current_len = 0;
+
+    const char *word_start = caption;
+    while (*word_start != '\0' && line_count < CAPTION_MAX_LINES) {
+        const char *word_end = word_start;
+        while (*word_end != '\0' && *word_end != ' ')
+            word_end++;
+        size_t word_len = (size_t) (word_end - word_start);
+        if (word_len > CAPTION_LINE_MAX_CHARS - 1) {
+            word_len = CAPTION_LINE_MAX_CHARS - 1;  // clip an absurdly long "word"
+        }
+
+        size_t needed = current_len + (current_len > 0 ? 1 : 0) + word_len;
+        if ((int) needed > chars_per_line && current_len > 0) {
+            strncpy(lines[line_count], current, CAPTION_LINE_MAX_CHARS - 1);
+            lines[line_count][CAPTION_LINE_MAX_CHARS - 1] = '\0';
+            line_count++;
+            current_len = 0;
+            current[0] = '\0';
+            if (line_count >= CAPTION_MAX_LINES) {
+                break;
+            }
+        }
+        if (current_len > 0) {
+            current[current_len++] = ' ';
+        }
+        memcpy(current + current_len, word_start, word_len);
+        current_len += word_len;
+        current[current_len] = '\0';
+
+        word_start = (*word_end == ' ') ? word_end + 1 : word_end;
+    }
+    if (line_count < CAPTION_MAX_LINES && current_len > 0) {
+        strncpy(lines[line_count], current, CAPTION_LINE_MAX_CHARS - 1);
+        lines[line_count][CAPTION_LINE_MAX_CHARS - 1] = '\0';
+        line_count++;
+    }
+
+    if (line_count == 0) {
+        return;
+    }
+
+    // Mark truncation with an ellipsis if there's leftover text.
+    if (*word_start != '\0') {
+        char *last = lines[line_count - 1];
+        size_t len = strlen(last);
+        size_t max_len = (size_t) chars_per_line;
+        if (len + 3 > max_len) {
+            len = (max_len > 3) ? max_len - 3 : 0;
+        }
+        last[len] = '\0';
+        strcat(last, "...");
+    }
+
+    int bar_height = line_count * (Font24.Height + CAPTION_LINE_PADDING) + CAPTION_LINE_PADDING;
+    if (bar_height > height) {
+        bar_height = height;
+    }
+    int bar_top = height - bar_height;
+
+    // Output in the exact theoretical palette values (matches what the
+    // dithering step already wrote) so the image stays a valid "processed"
+    // buffer: black bar, white text.
+    rgb_t bg = palette[0];
+    rgb_t fg = palette[1];
+
+    for (int y = bar_top; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            int idx = (y * width + x) * 3;
+            rgb_buffer[idx] = bg.r;
+            rgb_buffer[idx + 1] = bg.g;
+            rgb_buffer[idx + 2] = bg.b;
+        }
+    }
+
+    for (int i = 0; i < line_count; i++) {
+        int text_width = (int) strlen(lines[i]) * Font24.Width;
+        int x = (width - text_width) / 2;
+        if (x < CAPTION_LINE_PADDING) {
+            x = CAPTION_LINE_PADDING;
+        }
+        int y = bar_top + CAPTION_LINE_PADDING + i * (Font24.Height + CAPTION_LINE_PADDING);
+        for (const char *p = lines[i]; *p != '\0'; p++) {
+            draw_glyph(rgb_buffer, width, height, x, y, *p, fg);
+            x += Font24.Width;
+        }
+    }
+}
+
+esp_err_t image_processor_add_caption_to_file(const char *png_path, const char *caption)
+{
+    if (!caption || caption[0] == '\0') {
+        return ESP_OK;
+    }
+    if (!png_path) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    FILE *fp = fopen(png_path, "rb");
+    if (!fp) {
+        ESP_LOGE(TAG, "Failed to open %s for caption overlay", png_path);
+        return ESP_FAIL;
+    }
+    fseek(fp, 0, SEEK_END);
+    long file_size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+
+    uint8_t *file_buffer = (uint8_t *) heap_caps_malloc(file_size, MALLOC_CAP_SPIRAM);
+    if (!file_buffer) {
+        fclose(fp);
+        return ESP_ERR_NO_MEM;
+    }
+    size_t read_bytes = fread(file_buffer, 1, file_size, fp);
+    fclose(fp);
+    if (read_bytes != (size_t) file_size) {
+        heap_caps_free(file_buffer);
+        return ESP_FAIL;
+    }
+
+    uint8_t *rgb_buffer = NULL;
+    int width = 0, height = 0;
+    esp_err_t err = decode_png_buffer(file_buffer, file_size, &rgb_buffer, &width, &height);
+    heap_caps_free(file_buffer);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    image_processor_draw_caption(rgb_buffer, width, height, caption);
+
+    err = write_png_file(png_path, rgb_buffer, width, height);
+    heap_caps_free(rgb_buffer);
+    return err;
+}
+
+esp_err_t image_processor_write_rgb_to_png(const uint8_t *rgb_buffer, int width, int height,
+                                           const char *output_path)
+{
+    if (!rgb_buffer || !output_path || width <= 0 || height <= 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    return write_png_file(output_path, (uint8_t *) rgb_buffer, width, height);
 }

--- a/main/image_processor.h
+++ b/main/image_processor.h
@@ -83,6 +83,14 @@ image_format_t image_processor_detect_format_buffer(const uint8_t *data, size_t 
  * decoding pixel data. Used to classify portrait vs. landscape cheaply before
  * committing to a full decode.
  */
+/**
+ * @brief Same as image_processor_peek_dimensions(), but reads the leading
+ * bytes of a file itself rather than requiring the caller to already have a
+ * buffer - a header-only peek, not a full decode.
+ */
+esp_err_t image_processor_peek_file_dimensions(const char *path, image_format_t format, int *out_w,
+                                               int *out_h);
+
 esp_err_t image_processor_peek_dimensions(const uint8_t *data, size_t size, image_format_t format,
                                           int *out_width, int *out_height);
 
@@ -129,5 +137,14 @@ esp_err_t image_processor_add_caption_to_file(const char *png_path, const char *
  */
 esp_err_t image_processor_write_rgb_to_png(const uint8_t *rgb_buffer, int width, int height,
                                            const char *output_path);
+
+/**
+ * @brief Generates a small preview thumbnail from an already-processed PNG,
+ * nearest-neighbor downsampled to fit within max_dimension on its longer
+ * edge (aspect ratio preserved). Used for images that don't otherwise get a
+ * thumbnail sidecar generated client-side (e.g. Telegram downloads).
+ */
+esp_err_t image_processor_make_thumbnail(const char *source_png_path, int max_dimension,
+                                         const char *output_path);
 
 #endif

--- a/main/image_processor.h
+++ b/main/image_processor.h
@@ -179,10 +179,24 @@ esp_err_t image_processor_write_rgb_to_png(const uint8_t *rgb_buffer, int width,
 /**
  * @brief Generates a small preview thumbnail from an already-processed PNG,
  * nearest-neighbor downsampled to fit within max_dimension on its longer
- * edge (aspect ratio preserved). Used for images that don't otherwise get a
- * thumbnail sidecar generated client-side (e.g. Telegram downloads).
+ * edge (aspect ratio preserved). Use for images with no un-processed
+ * original available (e.g. a composed orientation-pair) - anything with an
+ * original should use image_processor_make_thumbnail_from_original()
+ * instead, so the preview reflects true colors, not the e-paper palette.
  */
 esp_err_t image_processor_make_thumbnail(const char *source_png_path, int max_dimension,
                                          const char *output_path);
+
+/**
+ * @brief Same as image_processor_make_thumbnail(), but decodes the source
+ * directly (JPG or PNG) with no e-paper processing (no CDR, no dithering,
+ * no palette quantization) - the thumbnail reflects the original photo's
+ * true colors, not the low-color-depth e-paper output. Use this for any
+ * source that still has an unprocessed original on disk (e.g. a freshly
+ * downloaded Telegram photo, before it's converted to a display-ready PNG).
+ */
+esp_err_t image_processor_make_thumbnail_from_original(const char *source_path,
+                                                        image_format_t format, int max_dimension,
+                                                        const char *output_path);
 
 #endif

--- a/main/image_processor.h
+++ b/main/image_processor.h
@@ -23,6 +23,21 @@ typedef enum {
     IMAGE_FORMAT_EPD_GZ
 } image_format_t;
 
+/**
+ * @brief Result structure for raw RGB buffer output (no PNG encoding)
+ *
+ * Only used by the Telegram-pairing/thumbnail helpers below, which need an
+ * in-RAM buffer to composite/downsample - everything else in this project
+ * uses the streaming, no-full-buffer path (image_processor_process_to_display
+ * / image_processor_process_or_display_png).
+ */
+typedef struct {
+    uint8_t *rgb_data;  // RGB888 buffer (caller must free with heap_caps_free)
+    size_t rgb_size;    // Size of RGB data in bytes (width * height * 3)
+    int width;          // Output image width
+    int height;         // Output image height
+} image_process_rgb_result_t;
+
 esp_err_t image_processor_init(void);
 
 /**
@@ -81,6 +96,20 @@ esp_err_t image_processor_reload_palette(void);
 const char *image_processor_get_last_error(void);
 
 image_format_t image_processor_detect_format(const char *input_path);
+
+/**
+ * @brief Whether a PNG file is already a fully processed, display-ready
+ * image: native panel dimensions and every pixel one of the panel's
+ * theoretical output colors. Used by the Telegram/pairing paths to decide
+ * whether a file can be shown as-is or needs (re-)processing first.
+ *
+ * Checks against the fixed theoretical palette only, not a board's
+ * calibrated/measured palette - a narrower check than
+ * image_processor_process_or_display_png()'s internal equivalent, but
+ * sufficient for its callers' purpose (avoid redundant reprocessing, not an
+ * exact calibration match).
+ */
+bool image_processor_is_processed(const char *input_path);
 
 /**
  * @brief Detect image format from buffer data

--- a/main/image_processor.h
+++ b/main/image_processor.h
@@ -78,4 +78,56 @@ image_format_t image_processor_detect_format(const char *input_path);
  */
 image_format_t image_processor_detect_format_buffer(const uint8_t *data, size_t size);
 
+/**
+ * @brief Read just the pixel dimensions of an encoded image (PNG/JPG) without
+ * decoding pixel data. Used to classify portrait vs. landscape cheaply before
+ * committing to a full decode.
+ */
+esp_err_t image_processor_peek_dimensions(const uint8_t *data, size_t size, image_format_t format,
+                                          int *out_width, int *out_height);
+
+/**
+ * @brief Compose two source images into one canvas at the board's native
+ * display resolution and process it exactly like a normal single image
+ * (cover-fit each half, then CDR + dither).
+ *
+ * Used to combine two mismatched-orientation Telegram photos (e.g. two
+ * portrait shots on a landscape frame) into one image instead of ever
+ * displaying one alone.
+ *
+ * @param stack_vertically false = side-by-side (for a landscape-mounted
+ * frame receiving portrait photos), true = stacked top/bottom (for a
+ * portrait-mounted frame receiving landscape photos).
+ */
+esp_err_t image_processor_compose_pair_to_rgb(const uint8_t *data_a, size_t size_a,
+                                              image_format_t format_a, const uint8_t *data_b,
+                                              size_t size_b, image_format_t format_b,
+                                              bool stack_vertically,
+                                              dither_algorithm_t dither_algorithm,
+                                              image_process_rgb_result_t *result);
+
+/**
+ * @brief Overlays a caption bar (solid background + wrapped bitmap-font text)
+ * across the bottom of an already-processed (dithered, palette-quantized)
+ * RGB888 buffer. Uses the exact display palette so the result stays a valid
+ * "processed" image. No-op if caption is NULL/empty.
+ */
+void image_processor_draw_caption(uint8_t *rgb_buffer, int width, int height, const char *caption);
+
+/**
+ * @brief Same as image_processor_draw_caption(), but reads an already
+ * display-processed PNG file, overlays the caption, and re-writes it in
+ * place (no re-dithering). No-op (returns ESP_OK) if caption is NULL/empty.
+ */
+esp_err_t image_processor_add_caption_to_file(const char *png_path, const char *caption);
+
+/**
+ * @brief Writes an already-processed RGB888 buffer to a PNG file. Thin
+ * wrapper so callers outside this module (e.g. the Telegram orientation-pair
+ * compositor) can persist a composed/captioned buffer without duplicating
+ * libpng plumbing.
+ */
+esp_err_t image_processor_write_rgb_to_png(const uint8_t *rgb_buffer, int width, int height,
+                                           const char *output_path);
+
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -22,6 +22,7 @@
 #include "esp_vfs_dev.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "history_manager.h"
 
 // External RTC support
 #ifdef CONFIG_EXT_RTC_ENABLED
@@ -581,6 +582,8 @@ void app_main(void)
     ESP_ERROR_CHECK(ota_manager_init());
 
     ESP_ERROR_CHECK(album_manager_init());
+
+    ESP_ERROR_CHECK(history_manager_init());
 
     // Check wake-up source
     wakeup_source_t wakeup_src = power_manager_get_wakeup_source();

--- a/main/main.c
+++ b/main/main.c
@@ -40,6 +40,7 @@
 #include "processing_settings.h"
 #include "splash_screen.h"
 #include "storage.h"
+#include "telegram_bot.h"
 #include "utils.h"
 #include "wifi_manager.h"
 #include "wifi_provisioning.h"
@@ -285,13 +286,21 @@ void deep_sleep_wake_main(wakeup_source_t wakeup_src)
         // Won't reach here after sleep
     }
 
-    // Initialize WiFi if needed (URL mode always needs it, SD card mode only if HA configured)
-    if (rotation_mode == ROTATION_MODE_URL || ha_configured) {
+    // Initialize WiFi if needed (URL/Telegram modes always need it, SD card mode only if HA
+    // configured)
+    if (rotation_mode == ROTATION_MODE_URL || rotation_mode == ROTATION_MODE_TELEGRAM ||
+        ha_configured) {
         ESP_LOGI(TAG, "Initializing WiFi for %s",
-                 rotation_mode == ROTATION_MODE_URL ? "URL rotation" : "HA battery post");
+                 rotation_mode == ROTATION_MODE_URL
+                     ? "URL rotation"
+                     : (rotation_mode == ROTATION_MODE_TELEGRAM ? "Telegram rotation"
+                                                                : "HA battery post"));
         ESP_ERROR_CHECK(wifi_manager_init());
 
-        if (connect_to_wifi_with_timeout(60)) {
+        bool connected_now = connect_to_wifi_with_timeout(60);
+        utils_handle_wifi_connect_result(connected_now);
+
+        if (connected_now) {
             wifi_connected = true;
             ESP_LOGI(TAG, "WiFi connected");
         } else {
@@ -352,6 +361,15 @@ void deep_sleep_wake_main(wakeup_source_t wakeup_src)
     // Trigger rotation
     power_manager_reset_sleep_timer();
     trigger_image_rotation();
+
+    // Telegram mode: run any "/" commands queued during the poll above (e.g.
+    // /status, /restart, /clear) now that the newest image has been
+    // displayed, and before we notify HA / open the config window / sleep.
+    // (The emergency "/telegram_reset" case already went straight to sleep
+    // from inside trigger_image_rotation() and never reaches this point.)
+    if (rotation_mode == ROTATION_MODE_TELEGRAM) {
+        telegram_bot_run_pending_commands();
+    }
 
     // Notify HA that data has been updated (after both OTA check and rotation)
     if (wifi_connected && ha_configured) {
@@ -735,7 +753,10 @@ void app_main(void)
 
     ESP_LOGI(TAG, "PhotoFrame started successfully");
 
-    // Delay OTA check to avoid competing with boot-time network activity
-    vTaskDelay(pdMS_TO_TICKS(10000));
-    ota_check_for_update(NULL, 0);
+    // Delay OTA check to avoid competing with boot-time network activity.
+    // A manual "check now" from the web UI bypasses this setting.
+    if (config_manager_get_ota_check_enabled()) {
+        vTaskDelay(pdMS_TO_TICKS(10000));
+        ota_check_for_update(NULL, 0);
+    }
 }

--- a/main/ota_manager.c
+++ b/main/ota_manager.c
@@ -7,6 +7,7 @@
 #include "board_hal.h"
 #include "cJSON.h"
 #include "config.h"
+#include "config_manager.h"
 #include "esp_crt_bundle.h"
 #include "esp_http_client.h"
 #include "esp_https_ota.h"
@@ -539,6 +540,13 @@ void ota_update_last_check_time(void)
 
 static esp_err_t ota_check_periodic_callback(void)
 {
+    if (!config_manager_get_ota_check_enabled()) {
+        ESP_LOGI(TAG, "Automatic OTA check disabled, skipping periodic check");
+        // Still counts as "run" so it doesn't retry every wake while disabled.
+        ota_update_last_check_time();
+        return ESP_OK;
+    }
+
     ESP_LOGI(TAG, "Periodic OTA check triggered");
 
     // Check for updates without notifying HA (HA will poll for status)

--- a/main/power_manager.c
+++ b/main/power_manager.c
@@ -115,7 +115,11 @@ static void sleep_timer_task(void *arg)
         bool usb_powered = board_hal_is_usb_connected();
         bool interactive_wake =
             (wakeup_source == WAKEUP_SOURCE_BOOT_BUTTON || wakeup_source == WAKEUP_SOURCE_NONE);
-        if (config_manager_get_deep_sleep_enabled()) {
+        if (!config_manager_get_wifi_performance_mode_enabled()) {
+            // User override: always stay in power-save, regardless of the
+            // tiered policy below (lower draw, slower web UI).
+            wifi_manager_set_performance_mode(false);
+        } else if (config_manager_get_deep_sleep_enabled()) {
             wifi_manager_set_performance_mode(interactive_wake || usb_powered);
         } else {
             wifi_manager_set_performance_mode(usb_powered);
@@ -179,20 +183,26 @@ static void power_manager_enable_auto_light_sleep(void)
     // and scale CPU frequency down to save power while maintaining WiFi connectivity
     esp_pm_config_t pm_config = {
         .max_freq_mhz = 160,  // Maximum CPU frequency (160MHz for ESP32-S3)
-        .min_freq_mhz = 40,   // Minimum CPU frequency (40MHz when idle)
 #ifdef BOARD_HAL_DISABLE_AUTO_LIGHT_SLEEP
-        // This board shares the SPI bus between the e-paper panel and the SD
-        // card; automatic light sleep disturbs the bus mid-transaction and
-        // corrupts SD reads. Keep CPU frequency scaling, but no light sleep.
+        // Pinning min == max disables esp_pm's dynamic frequency scaling
+        // outright, not just light sleep. Coredumps on this board show the
+        // crash (spinlock_acquire assert in esp_pm_impl_isr_hook ->
+        // leave_idle -> esp_pm_lock_acquire) still happens with light sleep
+        // off as long as min/max differ, i.e. DFS's lock/ISR-hook machinery
+        // is itself the trigger when a WiFi interrupt lands mid-transition,
+        // not specifically the light-sleep transition.
+        .min_freq_mhz = 160,
         .light_sleep_enable = false,
 #else
+        .min_freq_mhz = 40,   // Minimum CPU frequency (40MHz when idle)
         .light_sleep_enable = true,  // Enable automatic light sleep
 #endif
     };
 
     esp_err_t pm_ret = esp_pm_configure(&pm_config);
     if (pm_ret == ESP_OK) {
-        ESP_LOGI(TAG, "Power management configured (CPU: 160MHz -> 40MHz, light sleep %s)",
+        ESP_LOGI(TAG, "Power management configured (CPU: %dMHz -> %dMHz, light sleep %s)",
+                 pm_config.max_freq_mhz, pm_config.min_freq_mhz,
                  pm_config.light_sleep_enable ? "enabled" : "disabled");
     } else {
         ESP_LOGW(TAG, "Failed to configure power management: %s", esp_err_to_name(pm_ret));
@@ -203,7 +213,11 @@ static void power_manager_disable_auto_light_sleep(void)
 {
     esp_pm_config_t pm_config = {
         .max_freq_mhz = 160,  // Maximum CPU frequency (160MHz for ESP32-S3)
+#ifdef BOARD_HAL_DISABLE_AUTO_LIGHT_SLEEP
+        .min_freq_mhz = 160,  // Pin frequency: fully disables DFS, see above
+#else
         .min_freq_mhz = 40,   // Minimum CPU frequency (40MHz when idle)
+#endif
         .light_sleep_enable = false,
     };
 

--- a/main/telegram_bot.c
+++ b/main/telegram_bot.c
@@ -9,6 +9,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "album_manager.h"
 #include "board_hal.h"
 #include "cJSON.h"
 #include "config.h"
@@ -25,6 +26,7 @@
 #include "esp_vfs_fat.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "history_manager.h"
 #include "image_processor.h"
 #include "power_manager.h"
 #include "processing_settings.h"
@@ -723,7 +725,116 @@ static esp_err_t process_and_display_telegram_image(const char *path, const char
         image_processor_add_caption_to_file(CURRENT_PNG_PATH, caption);
     }
 
-    return display_manager_show_image(CURRENT_PNG_PATH);
+    esp_err_t show_err = display_manager_show_image(CURRENT_PNG_PATH);
+    if (show_err == ESP_OK) {
+        // CURRENT_PNG_PATH is a shared scratch file reused for every
+        // processed image, so display_manager_show_image()'s own history
+        // hook records the wrong identifier here - mark the real source
+        // path instead, so fallback album rotation (trigger_image_rotation)
+        // knows this specific Telegram image has already been shown.
+        history_manager_mark_shown(path);
+    }
+    return show_err;
+}
+
+// Generates a small preview thumbnail sidecar next to an already-persisted
+// (processed, display-ready) Telegram image, named "<basename>.jpg" - the
+// same sidecar convention the Web UI upload path uses (a client-generated
+// real JPEG there; here it's PNG-encoded bytes under a ".jpg" name, since
+// the firmware has no JPEG encoder - browsers render by sniffing content,
+// not by trusting the extension, so this displays fine). Using ".jpg"
+// unconditionally (not swapping to match the source's own extension) is
+// deliberate: the source is always finalized to ".png" by
+// finalize_telegram_image() before this runs, and a same-named ".png"
+// thumbnail would silently overwrite the full-size image it's a thumbnail
+// of. Best-effort: logs and returns on failure, never treated as fatal by
+// the caller - a missing thumbnail just falls back to the icon+filename
+// placeholder in the gallery.
+static void generate_telegram_thumbnail(const char *image_path)
+{
+    image_format_t format = image_processor_detect_format(image_path);
+    if (format != IMAGE_FORMAT_JPG && format != IMAGE_FORMAT_PNG) {
+        return;
+    }
+
+    const char *source_path = image_path;
+    if (format == IMAGE_FORMAT_JPG || !image_processor_is_processed(image_path)) {
+        // Shouldn't normally happen anymore (finalize_telegram_image() below
+        // converts to a processed PNG first) - kept as a defensive fallback
+        // for whatever it didn't convert (e.g. processing failed upstream).
+        dither_algorithm_t algo = processing_settings_get_dithering_algorithm();
+        esp_err_t err = image_processor_process(image_path, TELEGRAM_THUMB_SCRATCH_PATH, algo);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "Thumbnail: failed to process %s: %s", image_path,
+                     esp_err_to_name(err));
+            return;
+        }
+        source_path = TELEGRAM_THUMB_SCRATCH_PATH;
+    }
+
+    char thumb_path[320];
+    strncpy(thumb_path, image_path, sizeof(thumb_path) - 1);
+    thumb_path[sizeof(thumb_path) - 1] = '\0';
+    char *ext = strrchr(thumb_path, '.');
+    if (!ext || (size_t) (ext - thumb_path) + 4 >= sizeof(thumb_path)) {
+        return;
+    }
+    strcpy(ext, ".jpg");
+
+    esp_err_t err = image_processor_make_thumbnail(source_path, TELEGRAM_THUMBNAIL_MAX_DIMENSION,
+                                                   thumb_path);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Thumbnail: failed to generate for %s: %s", image_path,
+                 esp_err_to_name(err));
+    }
+}
+
+// Converts a downloaded Telegram image to a permanent, properly persisted
+// PNG in place (same directory/basename, extension -> .png) if it isn't
+// already one, then generates its thumbnail sidecar. Raw downloaded JPEGs
+// (the normal case - Telegram "photo" sends are always JPEG) otherwise stay
+// invisible to the rest of the system: the Web UI gallery
+// (album_images_handler) and fallback album rotation (rotate_sequential /
+// rotate_random in display_manager.c) both only recognize .bmp/.png/.epdgz,
+// never a bare .jpg. This is what a manual Web UI upload already gets for
+// free (client-side conversion before upload); Telegram downloads need it
+// done here instead, since there's no client-side step in that path.
+//
+// Must be called AFTER any orientation-mismatch/pairing decision that needs
+// the image's original aspect ratio: a "processed" PNG is always padded to
+// the panel's fixed display resolution, which no longer reflects the source
+// photo's own portrait/landscape shape.
+//
+// `path` is updated in place if the file was converted. Best-effort: on
+// processing failure, leaves `path` untouched (falls back to the original
+// raw file, same as before this existed) and only logs a warning.
+static void finalize_telegram_image(char *path, size_t path_len)
+{
+    image_format_t format = image_processor_detect_format(path);
+    bool needs_conversion =
+        (format == IMAGE_FORMAT_JPG || (format == IMAGE_FORMAT_PNG && !image_processor_is_processed(path)));
+
+    if (needs_conversion) {
+        char png_path[320];
+        strncpy(png_path, path, sizeof(png_path) - 1);
+        png_path[sizeof(png_path) - 1] = '\0';
+        char *ext = strrchr(png_path, '.');
+        if (ext && (size_t) (ext - png_path) + 4 < sizeof(png_path)) {
+            strcpy(ext, ".png");
+            dither_algorithm_t algo = processing_settings_get_dithering_algorithm();
+            esp_err_t err = image_processor_process(path, png_path, algo);
+            if (err == ESP_OK) {
+                unlink(path);
+                strncpy(path, png_path, path_len - 1);
+                path[path_len - 1] = '\0';
+            } else {
+                ESP_LOGW(TAG, "Failed to persist %s as PNG, keeping original: %s", path,
+                         esp_err_to_name(err));
+            }
+        }
+    }
+
+    generate_telegram_thumbnail(path);
 }
 
 // Reads an entire file into a heap_caps (SPIRAM) buffer.
@@ -758,25 +869,6 @@ static esp_err_t read_whole_file(const char *path, uint8_t **out_data, long *out
 
 // Reads just enough of a file to determine its pixel dimensions (bounded
 // read - reuses the same header-scan window as the progressive-JPEG check).
-static esp_err_t peek_file_dimensions(const char *path, image_format_t format, int *out_w,
-                                      int *out_h)
-{
-    FILE *f = fopen(path, "rb");
-    if (!f) {
-        return ESP_FAIL;
-    }
-    uint8_t *buf = malloc(JPEG_HEADER_SCAN_BYTES);
-    if (!buf) {
-        fclose(f);
-        return ESP_ERR_NO_MEM;
-    }
-    size_t n = fread(buf, 1, JPEG_HEADER_SCAN_BYTES, f);
-    fclose(f);
-    esp_err_t err = image_processor_peek_dimensions(buf, n, format, out_w, out_h);
-    free(buf);
-    return err;
-}
-
 // Whether the frame is currently mounted in portrait as *actually rendered*.
 // display_rotation_deg (not display_orientation, which is only ever sent as
 // an HTTP hint to external URL servers and has no on-device rendering
@@ -880,8 +972,8 @@ static void check_and_warn_low_battery(void)
     if (percent < TELEGRAM_LOW_BATTERY_THRESHOLD) {
         if (!config_manager_get_telegram_low_battery_warned()) {
             char msg[128];
-            snprintf(msg, sizeof(msg),
-                     "[!] Batteriewarnung: Nur noch %d%% verbleibend. Bitte bald aufladen.", percent);
+            snprintf(msg, sizeof(msg), "[!] Low battery warning: Only %d%% remaining. Please charge soon.",
+                     percent);
             telegram_bot_send_message(msg);
             config_manager_set_telegram_low_battery_warned(true);
         }
@@ -959,7 +1051,7 @@ static void send_wake_notification_if_enabled(void)
         return;
     }
     char wake_msg[900];
-    build_status_message("PhotoFrame wach", wake_msg, sizeof(wake_msg));
+    build_status_message("PhotoFrame awake", wake_msg, sizeof(wake_msg));
     telegram_bot_send_message(wake_msg);
 }
 
@@ -1032,7 +1124,7 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
         cJSON_Delete(root);
         send_wake_notification_if_enabled();
         if (out_result) {
-            *out_result = TELEGRAM_POLL_OK;
+            *out_result = TELEGRAM_POLL_OK_NO_IMAGE;
         }
         return ESP_OK;
     }
@@ -1067,7 +1159,7 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
         ESP_LOGW(TAG, "/telegram_reset received - discarding %d update(s), going to sleep", count);
         config_manager_set_telegram_last_update_id(max_update_id);
         cJSON_Delete(root);
-        telegram_bot_send_message("[OK] Reset ausgefuehrt, Warteschlange geloescht.");
+        telegram_bot_send_message("[OK] Reset executed, queue cleared.");
         if (out_result) {
             *out_result = TELEGRAM_POLL_RESET;
         }
@@ -1170,6 +1262,28 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
         if (got_image) {
             ESP_LOGI(TAG, "Saved Telegram image: %s", downloaded_path);
 
+            // Orientation mismatch must be checked against the ORIGINAL
+            // image's own aspect ratio, before finalize_telegram_image()
+            // below pads it to the panel's fixed display resolution.
+            bool mismatch = false;
+            if (pairing_enabled) {
+                image_format_t fmt = image_processor_detect_format(downloaded_path);
+                if (fmt == IMAGE_FORMAT_PNG || fmt == IMAGE_FORMAT_JPG) {
+                    int w = 0, h = 0;
+                    if (image_processor_peek_file_dimensions(downloaded_path, fmt, &w, &h) ==
+                            ESP_OK &&
+                        w > 0 && h > 0) {
+                        mismatch = ((h > w) != wants_portrait);
+                    }
+                }
+            }
+
+            // Persist as a proper processed PNG (+ thumbnail sidecar) so
+            // this image is visible to the Web UI gallery and fallback
+            // album rotation, same as any other album image - see
+            // finalize_telegram_image() for why a raw download isn't.
+            finalize_telegram_image(downloaded_path, sizeof(downloaded_path));
+
             if (saved_image_count < TELEGRAM_MAX_TRACKED_IMAGES) {
                 telegram_saved_image_t *entry = &saved_images[saved_image_count++];
                 strncpy(entry->path, downloaded_path, sizeof(entry->path) - 1);
@@ -1188,18 +1302,6 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
             } else {
                 ESP_LOGW(TAG, "Too many images in this batch, skipping reply confirmation for %s",
                          downloaded_path);
-            }
-
-            bool mismatch = false;
-            if (pairing_enabled) {
-                image_format_t fmt = image_processor_detect_format(downloaded_path);
-                if (fmt == IMAGE_FORMAT_PNG || fmt == IMAGE_FORMAT_JPG) {
-                    int w = 0, h = 0;
-                    if (peek_file_dimensions(downloaded_path, fmt, &w, &h) == ESP_OK && w > 0 &&
-                        h > 0) {
-                        mismatch = ((h > w) != wants_portrait);
-                    }
-                }
             }
 
             if (!mismatch) {
@@ -1239,6 +1341,7 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
                         paired = true;
 
                         if (pr->ok) {
+                            generate_telegram_thumbnail(pr->composed_path);
                             ESP_LOGI(TAG, "Composed and saved paired image: %s", pr->composed_path);
                             strncpy(display_path, pr->composed_path, sizeof(display_path) - 1);
                             display_path[sizeof(display_path) - 1] = '\0';
@@ -1282,9 +1385,9 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
         displayed = (disp_err == ESP_OK);
     } else if (image_attempt_failed) {
         telegram_bot_send_message(
-            "[FEHLER] Telegram-Bild konnte nicht geladen werden\n"
-            "(zu gross, nicht unterstuetztes Format, oder nur als progressives JPEG "
-            "verfuegbar). Bitte kleineres Bild oder als Datei senden.");
+            "[ERROR] Telegram image could not be loaded\n"
+            "(too large, unsupported format, or only available as a progressive JPEG). "
+            "Please send a smaller image or send it as a file.");
     }
 
     // Per-image "saved" confirmations, threaded as a reply to the original
@@ -1325,28 +1428,28 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
 
         if (this_pair_is_shown) {
             snprintf(caption_text, sizeof(caption_text),
-                     "[OK] Gespeichert & mit vorherigem Bild kombiniert angezeigt\n%.80s",
+                     "[OK] Saved & displayed combined with the previous image\n%.80s",
                      entry->filename);
         } else if (pair_index >= 0 && pair_results[pair_index].ok) {
             snprintf(caption_text, sizeof(caption_text),
-                     "[OK] Gespeichert & kombiniert im Album (nicht angezeigt)\n%.60s",
+                     "[OK] Saved & combined in the album (not displayed)\n%.60s",
                      entry->filename);
         } else if (pair_index >= 0) {
             snprintf(caption_text, sizeof(caption_text),
-                     "[!] Gespeichert, Kombination fehlgeschlagen\n%.80s", entry->filename);
+                     "[!] Saved, combining failed\n%.80s", entry->filename);
         } else if (this_is_shown && displayed) {
-            snprintf(caption_text, sizeof(caption_text), "[OK] Gespeichert & angezeigt\n%.100s",
+            snprintf(caption_text, sizeof(caption_text), "[OK] Saved & displayed\n%.100s",
                      entry->filename);
         } else if (this_is_shown) {
             snprintf(caption_text, sizeof(caption_text),
-                     "[!] Gespeichert (%.80s)\nAnzeige fehlgeschlagen: %.30s", entry->filename,
+                     "[!] Saved (%.80s)\nDisplay failed: %.30s", entry->filename,
                      esp_err_to_name(disp_err));
         } else if (still_pending) {
             snprintf(caption_text, sizeof(caption_text),
-                     "[OK] Gespeichert, wartet auf Hoch-/Querformat-Partnerbild\n%.100s",
+                     "[OK] Saved, waiting for a portrait/landscape partner image\n%.100s",
                      entry->filename);
         } else {
-            snprintf(caption_text, sizeof(caption_text), "[OK] Gespeichert (Warteschlange)\n%.100s",
+            snprintf(caption_text, sizeof(caption_text), "[OK] Saved (queued)\n%.100s",
                      entry->filename);
         }
 
@@ -1363,7 +1466,7 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
     config_manager_set_telegram_last_update_id(max_update_id);
 
     if (out_result) {
-        *out_result = TELEGRAM_POLL_OK;
+        *out_result = displayed ? TELEGRAM_POLL_OK : TELEGRAM_POLL_OK_NO_IMAGE;
     }
     return ESP_OK;
 }
@@ -1392,7 +1495,7 @@ static const char *reset_reason_string(void)
     case ESP_RST_BROWNOUT:
         return "Brownout";
     default:
-        return "Unbekannt";
+        return "Unknown";
     }
 }
 
@@ -1400,13 +1503,14 @@ static void format_battery(char *out, size_t out_len)
 {
     int percent;
     if (!get_valid_battery_percent(&percent)) {
-        snprintf(out, out_len, board_hal_is_usb_connected() ? "USB verbunden (kein Akku erkannt)"
-                                                             : "unbekannt");
+        snprintf(out, out_len, board_hal_is_usb_connected() ? "USB connected (no battery detected)"
+                                                             : "unknown");
         return;
     }
     int mv = board_hal_get_battery_voltage();
-    snprintf(out, out_len, "%d%% (%d mV)%s%s", percent, mv, board_hal_is_charging() ? ", laedt" : "",
-             board_hal_is_usb_connected() ? ", USB verbunden" : "");
+    snprintf(out, out_len, "%d%% (%d mV)%s%s", percent, mv,
+             board_hal_is_charging() ? ", charging" : "",
+             board_hal_is_usb_connected() ? ", USB connected" : "");
 }
 
 static void format_free_storage(char *out, size_t out_len)
@@ -1436,7 +1540,7 @@ static void format_free_storage(char *out, size_t out_len)
         return;
     }
     int percent = (total > 0) ? (int) ((free_bytes * 100ULL) / total) : 0;
-    snprintf(out, out_len, "%.1f/%.1f MB frei (%d%%)", free_bytes / (1024.0 * 1024.0),
+    snprintf(out, out_len, "%.1f/%.1f MB free (%d%%)", free_bytes / (1024.0 * 1024.0),
              total / (1024.0 * 1024.0), percent);
 }
 
@@ -1445,36 +1549,38 @@ static void format_heap(char *out, size_t out_len)
     size_t free_bytes = heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
     size_t total_bytes = heap_caps_get_total_size(MALLOC_CAP_DEFAULT);
     int percent = (total_bytes > 0) ? (int) ((free_bytes * 100ULL) / total_bytes) : 0;
-    snprintf(out, out_len, "%.1f/%.1f MB frei (%d%%)", free_bytes / (1024.0 * 1024.0),
+    snprintf(out, out_len, "%.1f/%.1f MB free (%d%%)", free_bytes / (1024.0 * 1024.0),
              total_bytes / (1024.0 * 1024.0), percent);
 }
 
 static void format_toggles(char *out, size_t out_len)
 {
     snprintf(out, out_len,
-             "[%c] Pairing (Hoch-/Quer-Kombi)\n"
+             "[%c] Telegram pairing (portrait/landscape combine)\n"
              "[%c] Deep Sleep\n"
              "[%c] Auto-Rotate\n"
-             "[%c] Wach-Auf-Meldung\n"
-             "[%c] Fehler-Overlay\n"
-             "[%c] WLAN-Performance",
+             "[%c] Wake notification\n"
+             "[%c] Error overlay\n"
+             "[%c] WiFi performance\n"
+             "[%c] Rotation pairing (random mode only)",
              config_manager_get_telegram_pairing_enabled() ? 'x' : ' ',
              config_manager_get_deep_sleep_enabled() ? 'x' : ' ',
              config_manager_get_auto_rotate() ? 'x' : ' ',
              config_manager_get_telegram_wake_notify_enabled() ? 'x' : ' ',
              config_manager_get_error_overlay_enabled() ? 'x' : ' ',
-             config_manager_get_wifi_performance_mode_enabled() ? 'x' : ' ');
+             config_manager_get_wifi_performance_mode_enabled() ? 'x' : ' ',
+             config_manager_get_rotation_pairing_enabled() ? 'x' : ' ');
 }
 
 static void format_rotation_schedule(char *out, size_t out_len)
 {
     if (!config_manager_get_auto_rotate()) {
-        snprintf(out, out_len, "Auto-Rotate deaktiviert");
+        snprintf(out, out_len, "Auto-Rotate disabled");
         return;
     }
     int count = config_manager_get_cron_rule_count();
     if (count == 0) {
-        snprintf(out, out_len, "kein Zeitplan konfiguriert");
+        snprintf(out, out_len, "no schedule configured");
         return;
     }
     size_t off = 0;
@@ -1521,17 +1627,17 @@ static void build_status_message(const char *title, char *out, size_t out_len)
     snprintf(out, out_len,
              "=== %s ===\n"
              "Firmware: %s (%s)\n"
-             "Neustartgrund: %s\n"
+             "Reset reason: %s\n"
              "\n"
-             "Batterie: %s\n"
-             "WLAN: %s (%s)\n"
+             "Battery: %s\n"
+             "WiFi: %s (%s)\n"
              "\n"
-             "Speicher: %s\n"
+             "Storage: %s\n"
              "Heap: %s\n"
              "\n"
-             "Rotations-Zeitplan: %s\n"
+             "Rotation schedule: %s\n"
              "\n"
-             "Einstellungen:\n"
+             "Settings:\n"
              "%s",
              title, app_desc->version, BOARD_HAL_NAME, reset_reason_string(), battery,
              ssid ? ssid : "n/a", ip_str, storage, heap, schedule, toggles);
@@ -1575,10 +1681,10 @@ static void execute_command(const char *raw_text)
         telegram_bot_send_message(msg);
     } else if (strcmp(cmd, "/clear") == 0) {
         esp_err_t err = display_manager_clear();
-        telegram_bot_send_message(err == ESP_OK ? "[OK] Anzeige geloescht."
-                                                 : "[FEHLER] Anzeige loeschen fehlgeschlagen.");
+        telegram_bot_send_message(err == ESP_OK ? "[OK] Display cleared."
+                                                 : "[ERROR] Failed to clear display.");
     } else if (strcmp(cmd, "/restart") == 0) {
-        telegram_bot_send_message("[OK] Neustart wird durchgefuehrt...");
+        telegram_bot_send_message("[OK] Restarting...");
         vTaskDelay(pdMS_TO_TICKS(500));  // give the HTTP send a moment to flush
         esp_restart();
         // Does not return.
@@ -1592,114 +1698,197 @@ static void execute_command(const char *raw_text)
         }
         char msg[160];
         snprintf(msg, sizeof(msg),
-                 "[%c] Hoch-/Querformat-Kombination\n"
-                 "Aktuelle Rahmenausrichtung: %s",
+                 "[%c] Portrait/landscape combining\n"
+                 "Current frame orientation: %s",
                  enabled ? 'x' : ' ',
-                 wants_portrait_frame_now() ? "Hochformat" : "Querformat");
+                 wants_portrait_frame_now() ? "portrait" : "landscape");
         telegram_bot_send_message(msg);
     } else if (strcmp(cmd, "/rotate_cron") == 0) {
         if (!args) {
             telegram_bot_send_message(
-                "[i] Verwendung: /rotate_cron <Minute Stunde Wochentag>\n"
-                "Beispiel: /rotate_cron 0 */12 *");
+                "[i] Usage: /rotate_cron <Minute Hour Weekday>\n"
+                "Example: /rotate_cron 0 */12 *");
         } else {
             cron_rule_t tmp;
             if (!cron_parse(args, &tmp)) {
                 char msg[192];
-                snprintf(msg, sizeof(msg), "[FEHLER] Ungueltiger Cron-Ausdruck: %.100s", args);
+                snprintf(msg, sizeof(msg), "[ERROR] Invalid cron expression: %.100s", args);
                 telegram_bot_send_message(msg);
             } else {
                 const char *one[1] = {args};
                 config_manager_set_cron_rules(one, 1);
                 power_manager_reset_rotate_timer();
                 char msg[192];
-                snprintf(msg, sizeof(msg), "[OK] Rotations-Zeitplan gesetzt: %.100s", args);
+                snprintf(msg, sizeof(msg), "[OK] Rotation schedule set: %.100s", args);
                 telegram_bot_send_message(msg);
             }
         }
     } else if (strcmp(cmd, "/deep_sleep") == 0) {
         if (args && strcasecmp(args, "on") == 0) {
             power_manager_set_deep_sleep_enabled(true);
-            telegram_bot_send_message("[x] Deep Sleep aktiviert.");
+            telegram_bot_send_message("[x] Deep Sleep enabled.");
         } else if (args && strcasecmp(args, "off") == 0) {
             power_manager_set_deep_sleep_enabled(false);
-            telegram_bot_send_message("[ ] Deep Sleep deaktiviert.");
+            telegram_bot_send_message("[ ] Deep Sleep disabled.");
         } else {
-            telegram_bot_send_message("[i] Verwendung: /deep_sleep on|off");
+            telegram_bot_send_message("[i] Usage: /deep_sleep on|off");
         }
     } else if (strcmp(cmd, "/auto_rotate") == 0) {
         if (args && strcasecmp(args, "on") == 0) {
             config_manager_set_auto_rotate(true);
             power_manager_reset_rotate_timer();
-            telegram_bot_send_message("[x] Auto-Rotate aktiviert.");
+            telegram_bot_send_message("[x] Auto-Rotate enabled.");
         } else if (args && strcasecmp(args, "off") == 0) {
             config_manager_set_auto_rotate(false);
-            telegram_bot_send_message("[ ] Auto-Rotate deaktiviert.");
+            telegram_bot_send_message("[ ] Auto-Rotate disabled.");
         } else {
-            telegram_bot_send_message("[i] Verwendung: /auto_rotate on|off");
+            telegram_bot_send_message("[i] Usage: /auto_rotate on|off");
         }
     } else if (strcmp(cmd, "/wake_notify") == 0) {
         if (args && strcasecmp(args, "on") == 0) {
             config_manager_set_telegram_wake_notify_enabled(true);
-            telegram_bot_send_message("[x] Wach-Auf-Benachrichtigung aktiviert.");
+            telegram_bot_send_message("[x] Wake notification enabled.");
         } else if (args && strcasecmp(args, "off") == 0) {
             config_manager_set_telegram_wake_notify_enabled(false);
-            telegram_bot_send_message("[ ] Wach-Auf-Benachrichtigung deaktiviert.");
+            telegram_bot_send_message("[ ] Wake notification disabled.");
         } else {
-            telegram_bot_send_message("[i] Verwendung: /wake_notify on|off");
+            telegram_bot_send_message("[i] Usage: /wake_notify on|off");
         }
     } else if (strcmp(cmd, "/error_overlay") == 0) {
         if (args && strcasecmp(args, "on") == 0) {
             config_manager_set_error_overlay_enabled(true);
-            telegram_bot_send_message("[x] Fehler-Overlay auf dem Display aktiviert.");
+            telegram_bot_send_message("[x] On-display error overlay enabled.");
         } else if (args && strcasecmp(args, "off") == 0) {
             config_manager_set_error_overlay_enabled(false);
-            telegram_bot_send_message("[ ] Fehler-Overlay auf dem Display deaktiviert.");
+            telegram_bot_send_message("[ ] On-display error overlay disabled.");
         } else {
-            telegram_bot_send_message("[i] Verwendung: /error_overlay on|off");
+            telegram_bot_send_message("[i] Usage: /error_overlay on|off");
         }
     } else if (strcmp(cmd, "/wifi_perf") == 0) {
         if (args && strcasecmp(args, "on") == 0) {
             config_manager_set_wifi_performance_mode_enabled(true);
             telegram_bot_send_message(
-                "[x] WLAN-Performance-Modus aktiviert\n(automatische Umschaltung je nach Kontext).");
+                "[x] WiFi performance mode enabled\n(automatically switches based on context).");
         } else if (args && strcasecmp(args, "off") == 0) {
             config_manager_set_wifi_performance_mode_enabled(false);
             telegram_bot_send_message(
-                "[ ] WLAN-Performance-Modus deaktiviert\n(immer Stromsparmodus, langsamere Web-UI).");
+                "[ ] WiFi performance mode disabled\n(always power-save, slower Web UI).");
         } else {
-            telegram_bot_send_message("[i] Verwendung: /wifi_perf on|off");
+            telegram_bot_send_message("[i] Usage: /wifi_perf on|off");
         }
+    } else if (strcmp(cmd, "/rotation_pairing") == 0) {
+        if (args && strcasecmp(args, "on") == 0) {
+            config_manager_set_rotation_pairing_enabled(true);
+            telegram_bot_send_message(
+                "[x] Auto-rotate orientation pairing enabled\n"
+                "(random rotation mode only - has no effect in sequential mode).");
+        } else if (args && strcasecmp(args, "off") == 0) {
+            config_manager_set_rotation_pairing_enabled(false);
+            telegram_bot_send_message("[ ] Auto-rotate orientation pairing disabled.");
+        } else {
+            telegram_bot_send_message("[i] Usage: /rotation_pairing on|off");
+        }
+    } else if (strcmp(cmd, "/list_albums") == 0) {
+        char **albums = NULL;
+        int count = 0;
+        if (album_manager_list_albums(&albums, &count) != ESP_OK) {
+            telegram_bot_send_message("[ERROR] Could not load albums.");
+        } else if (count == 0) {
+            telegram_bot_send_message("[i] No albums exist.");
+        } else {
+            char msg[900];
+            size_t off = 0;
+            int n = snprintf(msg, sizeof(msg), "=== Albums (%d) ===\n", count);
+            off = (n > 0) ? (size_t) n : 0;
+            for (int i = 0; i < count && off < sizeof(msg); i++) {
+                n = snprintf(msg + off, sizeof(msg) - off, "[%c] %.60s\n",
+                             album_manager_is_album_enabled(albums[i]) ? 'x' : ' ', albums[i]);
+                if (n < 0 || (size_t) n >= sizeof(msg) - off) {
+                    break;
+                }
+                off += (size_t) n;
+            }
+            telegram_bot_send_message(msg);
+        }
+        album_manager_free_album_list(albums, count);
+    } else if (strcmp(cmd, "/active_albums") == 0) {
+        char **albums = NULL;
+        int count = 0;
+        if (album_manager_get_enabled_albums(&albums, &count) != ESP_OK || count == 0) {
+            telegram_bot_send_message("[i] No active albums.");
+        } else {
+            char msg[900];
+            size_t off = 0;
+            int n = snprintf(msg, sizeof(msg), "=== Active albums (%d) ===\n", count);
+            off = (n > 0) ? (size_t) n : 0;
+            for (int i = 0; i < count && off < sizeof(msg); i++) {
+                n = snprintf(msg + off, sizeof(msg) - off, "%.60s\n", albums[i]);
+                if (n < 0 || (size_t) n >= sizeof(msg) - off) {
+                    break;
+                }
+                off += (size_t) n;
+            }
+            telegram_bot_send_message(msg);
+        }
+        album_manager_free_album_list(albums, count);
+    } else if (strcmp(cmd, "/enable_album") == 0) {
+        if (!args) {
+            telegram_bot_send_message("[i] Usage: /enable_album <albumname>");
+        } else if (!album_manager_album_exists(args)) {
+            char msg[192];
+            snprintf(msg, sizeof(msg), "[ERROR] Album not found: %.100s", args);
+            telegram_bot_send_message(msg);
+        } else {
+            esp_err_t aerr = album_manager_set_album_enabled(args, true);
+            char msg[192];
+            snprintf(msg, sizeof(msg),
+                     aerr == ESP_OK ? "[x] Album enabled: %.100s"
+                                    : "[ERROR] Could not enable album: %.100s",
+                     args);
+            telegram_bot_send_message(msg);
+        }
+    } else if (strcmp(cmd, "/clear_history") == 0) {
+        history_manager_clear();
+        // Also resets the sequential-rotation cursor so both rotation modes
+        // start a fresh cycle, not just the random-mode history set.
+        config_manager_set_last_index(-1);
+        telegram_bot_send_message("[OK] Display history cleared.");
     } else if (strcmp(cmd, "/help") == 0) {
         telegram_bot_send_message(
-            "=== Verfuegbare Befehle ===\n"
+            "=== Available commands ===\n"
             "\n"
             "Status:\n"
-            "/status - Status, Batterie, WLAN, Speicher, Einstellungen\n"
+            "/status - Status, battery, WiFi, storage, settings\n"
             "\n"
-            "Anzeige:\n"
-            "/clear - Anzeige loeschen\n"
-            "/restart - Neustart des Bilderrahmens\n"
-            "/pairing - Hoch-/Querformat-Kombination umschalten\n"
+            "Display:\n"
+            "/clear - Clear the display\n"
+            "/restart - Restart the photo frame\n"
+            "/pairing - Toggle portrait/landscape combining\n"
             "\n"
-            "Einstellungen (jeweils on|off, ohne Argument = Hilfe):\n"
-            "/rotate_cron <M H Wochentag> - Rotations-Zeitplan setzen\n"
+            "Albums:\n"
+            "/list_albums - List all albums\n"
+            "/active_albums - List active albums\n"
+            "/enable_album <albumname> - Enable an album\n"
+            "/clear_history - Clear the display history (restart the cycle)\n"
+            "\n"
+            "Settings (each on|off, no argument = help):\n"
+            "/rotate_cron <M H Weekday> - Set the rotation schedule\n"
             "/deep_sleep on|off\n"
             "/auto_rotate on|off\n"
-            "/wake_notify on|off - Status-Ping bei jedem Aufwachen\n"
-            "/error_overlay on|off - Fehlerhinweis auf dem Display\n"
-            "/wifi_perf on|off - WLAN-Performance-Modus\n"
+            "/wake_notify on|off - Status ping on every wake-up\n"
+            "/error_overlay on|off - On-display error notice\n"
+            "/wifi_perf on|off - WiFi performance mode\n"
+            "/rotation_pairing on|off - Combine mismatched-orientation images\n"
+            "  during auto-rotation (random mode only, no effect in sequential mode)\n"
             "\n"
-            "Notfall:\n"
-            "/telegram_reset - Warteschlange sofort leeren\n"
+            "Emergency:\n"
+            "/telegram_reset - Clear the queue immediately\n"
             "\n"
-            "Bilder koennen als Foto oder als Datei gesendet werden. Eine "
-            "Bildunterschrift wird als Overlay auf dem Bild angezeigt (ausser "
-            "sie beginnt mit \"/\").");
+            "Images can be sent as a photo or as a file. A caption is overlaid on the "
+            "image (unless it starts with \"/\").");
     } else {
         char msg[192];
-        snprintf(msg, sizeof(msg), "[FEHLER] Unbekannter Befehl: %s\nSiehe /help fuer eine Uebersicht.",
-                 cmd);
+        snprintf(msg, sizeof(msg), "[ERROR] Unknown command: %s\nSee /help for an overview.", cmd);
         telegram_bot_send_message(msg);
     }
 }

--- a/main/telegram_bot.c
+++ b/main/telegram_bot.c
@@ -1,0 +1,1713 @@
+#include "telegram_bot.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "board_hal.h"
+#include "cJSON.h"
+#include "config.h"
+#include "config_manager.h"
+#include "cron.h"
+#include "display_manager.h"
+#include "esp_app_desc.h"
+#include "esp_crt_bundle.h"
+#include "esp_heap_caps.h"
+#include "esp_http_client.h"
+#include "esp_littlefs.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "esp_vfs_fat.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "image_processor.h"
+#include "power_manager.h"
+#include "processing_settings.h"
+#include "storage.h"
+#include "wifi_manager.h"
+
+static const char *TAG = "telegram_bot";
+
+// Cap on the accumulated getUpdates/getFile response body. A batch of
+// TELEGRAM_MAX_UPDATES_PER_POLL updates comfortably fits well under this.
+#define TELEGRAM_MAX_RESPONSE_BYTES (256 * 1024)
+
+// Pending "/" commands queued by the last poll, executed (and replied to)
+// after the image has been displayed but before deep sleep. Reset on every
+// boot (deep sleep restarts the app), which matches the intended lifetime:
+// queue -> run -> sleep, once per wake.
+static char s_pending_commands[TELEGRAM_MAX_PENDING_COMMANDS][TELEGRAM_COMMAND_MAX_LEN];
+static int s_pending_command_count = 0;
+
+// ----------------------------------------------------------------------------
+// Small HTTP helpers
+// ----------------------------------------------------------------------------
+
+// Growing in-memory buffer used to capture GET response bodies (getUpdates,
+// getFile). Capped at TELEGRAM_MAX_RESPONSE_BYTES to bound worst-case heap use.
+typedef struct {
+    char *buf;
+    size_t len;
+    size_t cap;
+    bool overflow;
+} http_body_buf_t;
+
+static esp_err_t body_capture_handler(esp_http_client_event_t *evt)
+{
+    if (evt->event_id != HTTP_EVENT_ON_DATA) {
+        return ESP_OK;
+    }
+    http_body_buf_t *ctx = (http_body_buf_t *) evt->user_data;
+    if (ctx->overflow || evt->data_len <= 0) {
+        return ESP_OK;
+    }
+
+    size_t need = ctx->len + (size_t) evt->data_len + 1;
+    if (need > TELEGRAM_MAX_RESPONSE_BYTES) {
+        ESP_LOGW(TAG, "Response body exceeds %d bytes cap, truncating", TELEGRAM_MAX_RESPONSE_BYTES);
+        ctx->overflow = true;
+        return ESP_OK;
+    }
+    if (need > ctx->cap) {
+        size_t new_cap = ctx->cap ? ctx->cap * 2 : 4096;
+        while (new_cap < need) {
+            new_cap *= 2;
+        }
+        char *grown = realloc(ctx->buf, new_cap);
+        if (!grown) {
+            ESP_LOGE(TAG, "Out of memory growing response buffer to %zu bytes", new_cap);
+            ctx->overflow = true;
+            return ESP_OK;
+        }
+        ctx->buf = grown;
+        ctx->cap = new_cap;
+    }
+
+    memcpy(ctx->buf + ctx->len, evt->data, evt->data_len);
+    ctx->len += evt->data_len;
+    ctx->buf[ctx->len] = '\0';
+    return ESP_OK;
+}
+
+// Transient TLS/network hiccups (e.g. a failed mbedtls handshake against
+// api.telegram.org) are common enough on ESP32 to warrant a couple of quick
+// retries, mirroring the retry loop already used for image-server fetches in
+// utils.c - a single blip shouldn't cost the whole poll cycle (missed
+// images/commands until the next wake).
+#define TELEGRAM_HTTP_RETRY_COUNT 3
+#define TELEGRAM_HTTP_RETRY_DELAY_MS 1500
+
+// Every Telegram API URL embeds the bot token as ".../bot<TOKEN>/...". NEVER
+// log a raw URL - always redact through this first (a device log, including
+// the downloadable debug log, is not a safe place for a live bot token).
+static void redact_url_for_log(const char *url, char *out, size_t out_len)
+{
+    const char *marker = "/bot";
+    const char *pos = strstr(url, marker);
+    if (!pos) {
+        strncpy(out, url, out_len - 1);
+        out[out_len - 1] = '\0';
+        return;
+    }
+
+    size_t prefix_len = (size_t) (pos - url) + strlen(marker);
+    if (prefix_len >= out_len) {
+        out[0] = '\0';
+        return;
+    }
+    const char *token_start = pos + strlen(marker);
+    const char *next_slash = strchr(token_start, '/');
+
+    memcpy(out, url, prefix_len);
+    out[prefix_len] = '\0';
+    snprintf(out + prefix_len, out_len - prefix_len, "***%s", next_slash ? next_slash : "");
+}
+
+// Performs a GET request (with retry on transient failure) and returns the
+// response body (caller frees with free()). *out_body is NULL on any failure.
+static esp_err_t telegram_http_get(const char *url, int timeout_ms, char **out_body,
+                                   size_t *out_len)
+{
+    *out_body = NULL;
+    if (out_len) {
+        *out_len = 0;
+    }
+
+    esp_err_t last_err = ESP_FAIL;
+    char safe_url[160];
+    redact_url_for_log(url, safe_url, sizeof(safe_url));
+
+    for (int attempt = 1; attempt <= TELEGRAM_HTTP_RETRY_COUNT; attempt++) {
+        if (attempt > 1) {
+            ESP_LOGW(TAG, "Retrying GET (%d/%d) after %d ms...", attempt, TELEGRAM_HTTP_RETRY_COUNT,
+                     TELEGRAM_HTTP_RETRY_DELAY_MS);
+            vTaskDelay(pdMS_TO_TICKS(TELEGRAM_HTTP_RETRY_DELAY_MS));
+        }
+
+        http_body_buf_t ctx = {0};
+
+        esp_http_client_config_t config = {
+            .url = url,
+            .timeout_ms = timeout_ms,
+            .event_handler = body_capture_handler,
+            .user_data = &ctx,
+            .buffer_size = 2048,
+            .crt_bundle_attach = esp_crt_bundle_attach,
+        };
+
+        esp_http_client_handle_t client = esp_http_client_init(&config);
+        if (!client) {
+            ESP_LOGE(TAG, "Failed to init HTTP client for GET %s", safe_url);
+            free(ctx.buf);
+            last_err = ESP_FAIL;
+            continue;
+        }
+
+        esp_err_t err = esp_http_client_perform(client);
+        int status = esp_http_client_get_status_code(client);
+        esp_http_client_cleanup(client);
+
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "GET %s failed: %s", safe_url, esp_err_to_name(err));
+            free(ctx.buf);
+            last_err = err;
+            continue;
+        }
+        if (status != 200 || ctx.overflow || !ctx.buf) {
+            ESP_LOGE(TAG, "GET %s returned HTTP %d%s", safe_url, status,
+                     ctx.overflow ? " (truncated)" : "");
+            free(ctx.buf);
+            last_err = ESP_FAIL;
+            continue;
+        }
+
+        *out_body = ctx.buf;
+        if (out_len) {
+            *out_len = ctx.len;
+        }
+        return ESP_OK;
+    }
+
+    return last_err;
+}
+
+// Downloads raw bytes (a Telegram file) straight to a local file.
+typedef struct {
+    FILE *file;
+    int total_bytes;
+} file_download_ctx_t;
+
+static esp_err_t file_download_handler(esp_http_client_event_t *evt)
+{
+    if (evt->event_id != HTTP_EVENT_ON_DATA) {
+        return ESP_OK;
+    }
+    file_download_ctx_t *ctx = (file_download_ctx_t *) evt->user_data;
+    if (ctx->file && evt->data_len > 0) {
+        fwrite(evt->data, 1, evt->data_len, ctx->file);
+        ctx->total_bytes += evt->data_len;
+    }
+    return ESP_OK;
+}
+
+// Retries a couple of times on transient failure before letting the
+// progressive size fallback (in download_photo_with_fallback) give up on this
+// size entirely - a quick retry at the preferred size beats silently
+// dropping to a lower-quality one over a one-off network blip.
+#define TELEGRAM_DOWNLOAD_RETRY_COUNT 2
+#define TELEGRAM_DOWNLOAD_RETRY_DELAY_MS 1500
+
+static esp_err_t telegram_download_to_file(const char *url, const char *local_path)
+{
+    for (int attempt = 1; attempt <= TELEGRAM_DOWNLOAD_RETRY_COUNT; attempt++) {
+        if (attempt > 1) {
+            ESP_LOGW(TAG, "Retrying download (%d/%d) after %d ms...", attempt,
+                     TELEGRAM_DOWNLOAD_RETRY_COUNT, TELEGRAM_DOWNLOAD_RETRY_DELAY_MS);
+            vTaskDelay(pdMS_TO_TICKS(TELEGRAM_DOWNLOAD_RETRY_DELAY_MS));
+        }
+
+        FILE *f = fopen(local_path, "wb");
+        if (!f) {
+            ESP_LOGE(TAG, "Failed to open %s for writing", local_path);
+            return ESP_FAIL;
+        }
+
+        file_download_ctx_t ctx = {.file = f, .total_bytes = 0};
+        esp_http_client_config_t config = {
+            .url = url,
+            .timeout_ms = TELEGRAM_HTTP_TIMEOUT_MS,
+            .event_handler = file_download_handler,
+            .user_data = &ctx,
+            .buffer_size = 4096,
+            .crt_bundle_attach = esp_crt_bundle_attach,
+        };
+
+        esp_http_client_handle_t client = esp_http_client_init(&config);
+        if (!client) {
+            fclose(f);
+            unlink(local_path);
+            continue;
+        }
+
+        esp_err_t err = esp_http_client_perform(client);
+        int status = esp_http_client_get_status_code(client);
+        fclose(f);
+        esp_http_client_cleanup(client);
+
+        if (err != ESP_OK || status != 200 || ctx.total_bytes <= 0) {
+            ESP_LOGW(TAG, "File download failed (err=%s, status=%d, bytes=%d)", esp_err_to_name(err),
+                     status, ctx.total_bytes);
+            unlink(local_path);
+            continue;
+        }
+
+        ESP_LOGI(TAG, "Downloaded %d bytes to %s", ctx.total_bytes, local_path);
+        return ESP_OK;
+    }
+
+    return ESP_FAIL;
+}
+
+// ----------------------------------------------------------------------------
+// Telegram Bot API method helpers
+// ----------------------------------------------------------------------------
+
+static void build_api_url(const char *method, char *out, size_t out_len)
+{
+    snprintf(out, out_len, TELEGRAM_API_BASE_FMT, config_manager_get_telegram_bot_token(), method);
+}
+
+// POSTs a JSON body to a Telegram API method with retry on transient failure.
+// Takes ownership of `body` (always deletes it).
+static esp_err_t telegram_api_post(const char *method, cJSON *body)
+{
+    char *payload = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+    if (!payload) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    char url[256];
+    build_api_url(method, url, sizeof(url));
+
+    esp_err_t result = ESP_FAIL;
+    for (int attempt = 1; attempt <= TELEGRAM_HTTP_RETRY_COUNT; attempt++) {
+        if (attempt > 1) {
+            ESP_LOGW(TAG, "Retrying %s (%d/%d) after %d ms...", method, attempt,
+                     TELEGRAM_HTTP_RETRY_COUNT, TELEGRAM_HTTP_RETRY_DELAY_MS);
+            vTaskDelay(pdMS_TO_TICKS(TELEGRAM_HTTP_RETRY_DELAY_MS));
+        }
+
+        esp_http_client_config_t config = {
+            .url = url,
+            .method = HTTP_METHOD_POST,
+            .timeout_ms = TELEGRAM_HTTP_TIMEOUT_MS,
+            .crt_bundle_attach = esp_crt_bundle_attach,
+        };
+        esp_http_client_handle_t client = esp_http_client_init(&config);
+        if (!client) {
+            continue;
+        }
+
+        esp_http_client_set_header(client, "Content-Type", "application/json");
+        esp_http_client_set_post_field(client, payload, strlen(payload));
+
+        esp_err_t err = esp_http_client_perform(client);
+        int status = esp_http_client_get_status_code(client);
+        esp_http_client_cleanup(client);
+
+        if (err != ESP_OK || status != 200) {
+            ESP_LOGW(TAG, "%s failed (err=%s, status=%d)", method, esp_err_to_name(err), status);
+            continue;
+        }
+        result = ESP_OK;
+        break;
+    }
+
+    free(payload);
+    return result;
+}
+
+esp_err_t telegram_bot_send_message(const char *text)
+{
+    if (!config_manager_telegram_is_configured() || !text) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    cJSON *body = cJSON_CreateObject();
+    if (!body) {
+        return ESP_ERR_NO_MEM;
+    }
+    cJSON_AddStringToObject(body, "chat_id", config_manager_get_telegram_chat_id());
+    cJSON_AddStringToObject(body, "text", text);
+    return telegram_api_post("sendMessage", body);
+}
+
+// Same as telegram_bot_send_message(), but threaded as a reply to a specific
+// message (reply_to_message_id <= 0 means "no threading").
+static esp_err_t telegram_bot_send_message_reply(const char *text, int64_t reply_to_message_id)
+{
+    if (!config_manager_telegram_is_configured() || !text) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    cJSON *body = cJSON_CreateObject();
+    if (!body) {
+        return ESP_ERR_NO_MEM;
+    }
+    cJSON_AddStringToObject(body, "chat_id", config_manager_get_telegram_chat_id());
+    cJSON_AddStringToObject(body, "text", text);
+    if (reply_to_message_id > 0) {
+        cJSON_AddNumberToObject(body, "reply_to_message_id", (double) reply_to_message_id);
+    }
+    return telegram_api_post("sendMessage", body);
+}
+
+// Sends a photo the bot already knows about (by file_id - no re-upload needed)
+// as a captioned reply to a specific message. Used for the per-image "saved"
+// confirmation, echoing back the smallest available Telegram-hosted size.
+static esp_err_t telegram_bot_send_photo_reply(const char *file_id, const char *caption,
+                                               int64_t reply_to_message_id)
+{
+    if (!config_manager_telegram_is_configured() || !file_id || file_id[0] == '\0') {
+        return ESP_ERR_INVALID_STATE;
+    }
+    cJSON *body = cJSON_CreateObject();
+    if (!body) {
+        return ESP_ERR_NO_MEM;
+    }
+    cJSON_AddStringToObject(body, "chat_id", config_manager_get_telegram_chat_id());
+    cJSON_AddStringToObject(body, "photo", file_id);
+    if (caption) {
+        cJSON_AddStringToObject(body, "caption", caption);
+    }
+    if (reply_to_message_id > 0) {
+        cJSON_AddNumberToObject(body, "reply_to_message_id", (double) reply_to_message_id);
+    }
+    return telegram_api_post("sendPhoto", body);
+}
+
+// Resolves a Telegram file_id to a downloadable file_path via getFile.
+static esp_err_t telegram_get_file_path(const char *file_id, char *out_path, size_t out_len)
+{
+    char base[256];
+    build_api_url("getFile", base, sizeof(base));
+    char url[320];
+    snprintf(url, sizeof(url), "%s?file_id=%s", base, file_id);
+
+    char *body = NULL;
+    esp_err_t err = telegram_http_get(url, TELEGRAM_HTTP_TIMEOUT_MS, &body, NULL);
+    if (err != ESP_OK || !body) {
+        free(body);
+        return ESP_FAIL;
+    }
+
+    cJSON *root = cJSON_Parse(body);
+    free(body);
+    if (!root) {
+        ESP_LOGE(TAG, "getFile: failed to parse JSON response");
+        return ESP_FAIL;
+    }
+
+    esp_err_t ret = ESP_FAIL;
+    cJSON *ok = cJSON_GetObjectItem(root, "ok");
+    cJSON *result = cJSON_GetObjectItem(root, "result");
+    if (ok && cJSON_IsTrue(ok) && result) {
+        cJSON *fp = cJSON_GetObjectItem(result, "file_path");
+        if (fp && cJSON_IsString(fp)) {
+            strncpy(out_path, fp->valuestring, out_len - 1);
+            out_path[out_len - 1] = '\0';
+            ret = ESP_OK;
+        }
+    } else {
+        cJSON *desc = cJSON_GetObjectItem(root, "description");
+        ESP_LOGW(TAG, "getFile failed: %s",
+                 (desc && cJSON_IsString(desc)) ? desc->valuestring : "unknown error");
+    }
+    cJSON_Delete(root);
+    return ret;
+}
+
+static esp_err_t telegram_download_file_id(const char *file_id, const char *local_path)
+{
+    char tg_file_path[256];
+    if (telegram_get_file_path(file_id, tg_file_path, sizeof(tg_file_path)) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    char url[400];
+    snprintf(url, sizeof(url), "https://" TELEGRAM_API_HOST "/file/bot%s/%s",
+             config_manager_get_telegram_bot_token(), tg_file_path);
+    return telegram_download_to_file(url, local_path);
+}
+
+// ----------------------------------------------------------------------------
+// Progressive-JPEG detection
+// ----------------------------------------------------------------------------
+
+// Telegram re-encodes compressed "photo" messages as progressive JPEG, which
+// this firmware's JPEG decoder (tjpgd-based) cannot decode (only baseline/
+// sequential SOF0/SOF1). Scan the JPEG marker stream for SOF0/1 (baseline,
+// OK) vs SOF2/3 (progressive/lossless, unsupported) so a bad download can be
+// treated as a failure and trigger the same progressive size fallback used
+// for "file too large". Only the first chunk is scanned - SOF markers appear
+// before the entropy-coded scan data, which starts well within this window
+// for realistic Telegram photos/thumbnails.
+#define JPEG_HEADER_SCAN_BYTES 65536
+
+static bool jpeg_file_is_progressive(const char *path)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        return false;
+    }
+
+    uint8_t *buf = malloc(JPEG_HEADER_SCAN_BYTES);
+    if (!buf) {
+        fclose(f);
+        return false;
+    }
+
+    size_t n = fread(buf, 1, JPEG_HEADER_SCAN_BYTES, f);
+    fclose(f);
+
+    bool is_progressive = false;
+    if (n >= 4 && buf[0] == 0xFF && buf[1] == 0xD8) {
+        size_t i = 2;
+        while (i + 4 <= n) {
+            if (buf[i] != 0xFF) {
+                i++;
+                continue;
+            }
+            uint8_t marker = buf[i + 1];
+            // Markers with no payload (RSTn, SOI dup, TEM, padding 0xFF).
+            if (marker == 0x01 || (marker >= 0xD0 && marker <= 0xD9) || marker == 0xFF) {
+                i += 2;
+                continue;
+            }
+            uint16_t seg_len = (uint16_t) ((buf[i + 2] << 8) | buf[i + 3]);
+            if (marker == 0xC0 || marker == 0xC1) {  // SOF0 / SOF1: baseline / extended sequential
+                break;
+            }
+            if (marker == 0xC2 || marker == 0xC3) {  // SOF2 / SOF3: progressive / lossless
+                is_progressive = true;
+                break;
+            }
+            if (marker == 0xDA) {  // SOS: entropy-coded data follows, no SOF found before it
+                break;
+            }
+            if (seg_len < 2) {
+                break;  // malformed segment length, stop scanning
+            }
+            i += 2 + seg_len;
+        }
+    }
+
+    free(buf);
+    return is_progressive;
+}
+
+// ----------------------------------------------------------------------------
+// Image download with progressive-size fallback
+// ----------------------------------------------------------------------------
+
+static esp_err_t make_unique_telegram_path(const char *ext, char *out, size_t out_len)
+{
+    time_t now = time(NULL);
+    for (int suffix = 0; suffix < 100; suffix++) {
+        if (suffix == 0) {
+            snprintf(out, out_len, "%s/img_%lld.%s", TELEGRAM_DOWNLOAD_DIRECTORY, (long long) now,
+                     ext);
+        } else {
+            snprintf(out, out_len, "%s/img_%lld_%d.%s", TELEGRAM_DOWNLOAD_DIRECTORY,
+                     (long long) now, suffix, ext);
+        }
+        struct stat st;
+        if (stat(out, &st) != 0) {
+            return ESP_OK;  // path is free
+        }
+    }
+    ESP_LOGE(TAG, "Could not find a free filename under %s", TELEGRAM_DOWNLOAD_DIRECTORY);
+    return ESP_FAIL;
+}
+
+// Downloads a Telegram "photo" (array of re-encoded resolutions, ascending
+// size) trying the largest first. Falls back to the next smaller size when
+// the current one is too large for getFile, fails to download, or turns out
+// to be a progressive JPEG we can't decode - until one succeeds or the
+// smallest size has also failed.
+//
+// out_thumb_file_id is filled with the smallest available size's file_id
+// regardless of which size was actually saved - Telegram already hosts it,
+// so it can be echoed straight back via sendPhoto as a lightweight "saved"
+// confirmation without re-uploading anything.
+static esp_err_t download_photo_with_fallback(cJSON *photo_array, char *out_path,
+                                               size_t out_path_len, char *out_thumb_file_id,
+                                               size_t out_thumb_file_id_len)
+{
+    if (out_thumb_file_id && out_thumb_file_id_len > 0) {
+        out_thumb_file_id[0] = '\0';
+        cJSON *smallest = cJSON_GetArrayItem(photo_array, 0);
+        cJSON *smallest_id = smallest ? cJSON_GetObjectItem(smallest, "file_id") : NULL;
+        if (smallest_id && cJSON_IsString(smallest_id)) {
+            strncpy(out_thumb_file_id, smallest_id->valuestring, out_thumb_file_id_len - 1);
+            out_thumb_file_id[out_thumb_file_id_len - 1] = '\0';
+        }
+    }
+
+    int n = cJSON_GetArraySize(photo_array);
+    for (int i = n - 1; i >= 0; i--) {
+        cJSON *size_obj = cJSON_GetArrayItem(photo_array, i);
+        cJSON *file_id_item = cJSON_GetObjectItem(size_obj, "file_id");
+        if (!file_id_item || !cJSON_IsString(file_id_item)) {
+            continue;
+        }
+
+        cJSON *fsize_item = cJSON_GetObjectItem(size_obj, "file_size");
+        int approx_kb =
+            (fsize_item && cJSON_IsNumber(fsize_item)) ? (int) (fsize_item->valuedouble / 1024) : -1;
+        ESP_LOGI(TAG, "Trying Telegram photo size %d/%d (~%d KB)", i + 1, n, approx_kb);
+
+        if (make_unique_telegram_path("jpg", out_path, out_path_len) != ESP_OK) {
+            return ESP_FAIL;
+        }
+
+        if (telegram_download_file_id(file_id_item->valuestring, out_path) != ESP_OK) {
+            ESP_LOGW(TAG, "Size %d/%d failed to download, falling back to smaller", i + 1, n);
+            continue;
+        }
+
+        if (jpeg_file_is_progressive(out_path)) {
+            ESP_LOGW(TAG,
+                     "Size %d/%d is a progressive JPEG (unsupported by decoder), falling back to "
+                     "smaller",
+                     i + 1, n);
+            unlink(out_path);
+            continue;
+        }
+
+        return ESP_OK;
+    }
+
+    ESP_LOGE(TAG, "All %d photo size(s) failed (progressive fallback exhausted)", n);
+    return ESP_FAIL;
+}
+
+// Documents (files sent "as file") are not re-encoded by Telegram, so they
+// keep their original format/encoding and there is only a single size - no
+// fallback ladder to walk, just one attempt.
+static bool document_pick_extension(cJSON *document, const char **out_ext)
+{
+    cJSON *mime = cJSON_GetObjectItem(document, "mime_type");
+    cJSON *fname = cJSON_GetObjectItem(document, "file_name");
+    const char *ext = NULL;
+
+    if (mime && cJSON_IsString(mime)) {
+        const char *m = mime->valuestring;
+        if (strcmp(m, "image/jpeg") == 0) {
+            ext = "jpg";
+        } else if (strcmp(m, "image/png") == 0) {
+            ext = "png";
+        } else if (strcmp(m, "image/bmp") == 0 || strcmp(m, "image/x-ms-bmp") == 0) {
+            ext = "bmp";
+        }
+    }
+    if (!ext && fname && cJSON_IsString(fname)) {
+        const char *dot = strrchr(fname->valuestring, '.');
+        if (dot) {
+            if (strcasecmp(dot, ".jpg") == 0 || strcasecmp(dot, ".jpeg") == 0) {
+                ext = "jpg";
+            } else if (strcasecmp(dot, ".png") == 0) {
+                ext = "png";
+            } else if (strcasecmp(dot, ".bmp") == 0) {
+                ext = "bmp";
+            } else if (strcasecmp(dot, ".epdgz") == 0) {
+                ext = "epdgz";
+            }
+        }
+    }
+
+    *out_ext = ext;
+    return ext != NULL;
+}
+
+// out_thumb_file_id is filled from the document's own "thumbnail" (or the
+// older "thumb" field name), if Telegram provided one - documents have no
+// smaller sizes of their own, so this is the only lightweight option for a
+// photo-reply confirmation; left empty if unavailable (caller falls back to
+// a plain text reply).
+static esp_err_t download_document_image(cJSON *document, char *out_path, size_t out_path_len,
+                                          char *out_thumb_file_id, size_t out_thumb_file_id_len)
+{
+    if (out_thumb_file_id && out_thumb_file_id_len > 0) {
+        out_thumb_file_id[0] = '\0';
+        cJSON *thumb = cJSON_GetObjectItem(document, "thumbnail");
+        if (!thumb) {
+            thumb = cJSON_GetObjectItem(document, "thumb");
+        }
+        cJSON *thumb_id = thumb ? cJSON_GetObjectItem(thumb, "file_id") : NULL;
+        if (thumb_id && cJSON_IsString(thumb_id)) {
+            strncpy(out_thumb_file_id, thumb_id->valuestring, out_thumb_file_id_len - 1);
+            out_thumb_file_id[out_thumb_file_id_len - 1] = '\0';
+        }
+    }
+
+    cJSON *file_id_item = cJSON_GetObjectItem(document, "file_id");
+    if (!file_id_item || !cJSON_IsString(file_id_item)) {
+        return ESP_FAIL;
+    }
+
+    const char *ext = NULL;
+    if (!document_pick_extension(document, &ext)) {
+        ESP_LOGW(TAG, "Document has an unsupported format, skipping");
+        return ESP_FAIL;
+    }
+
+    if (make_unique_telegram_path(ext, out_path, out_path_len) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    if (telegram_download_file_id(file_id_item->valuestring, out_path) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    if (strcmp(ext, "jpg") == 0 && jpeg_file_is_progressive(out_path)) {
+        ESP_LOGW(TAG, "Document JPEG is progressive (unsupported by decoder)");
+        unlink(out_path);
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+// Runs the downloaded image through the existing processing pipeline (same
+// format handling as fetch_and_save_image_from_url in utils.c: EPDGZ/BMP are
+// already display-ready, PNG/JPG go through image_processor_process) and
+// shows it. The original file under TELEGRAM_DOWNLOAD_DIRECTORY is left in
+// place for later rotation cycles.
+//
+// If `caption` is non-empty, it's overlaid as a caption bar on the displayed
+// image (only supported for the PNG/JPG path - EPDGZ/BMP are already
+// display-ready blobs with no RGB buffer to draw into).
+static esp_err_t process_and_display_telegram_image(const char *path, const char *caption)
+{
+    image_format_t format = image_processor_detect_format(path);
+
+    if (format == IMAGE_FORMAT_EPD_GZ || format == IMAGE_FORMAT_BMP) {
+        return display_manager_show_image(path);
+    }
+
+    if (format != IMAGE_FORMAT_PNG && format != IMAGE_FORMAT_JPG) {
+        ESP_LOGE(TAG, "Unsupported/undetected image format for %s", path);
+        return ESP_FAIL;
+    }
+
+    if (format == IMAGE_FORMAT_PNG && image_processor_is_processed(path)) {
+        if (caption && caption[0] != '\0') {
+            image_processor_add_caption_to_file(path, caption);
+        }
+        return display_manager_show_image(path);
+    }
+
+    dither_algorithm_t algo = processing_settings_get_dithering_algorithm();
+    esp_err_t err = image_processor_process(path, CURRENT_PNG_PATH, algo);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to process Telegram image %s: %s", path, esp_err_to_name(err));
+        return err;
+    }
+
+    if (caption && caption[0] != '\0') {
+        image_processor_add_caption_to_file(CURRENT_PNG_PATH, caption);
+    }
+
+    return display_manager_show_image(CURRENT_PNG_PATH);
+}
+
+// Reads an entire file into a heap_caps (SPIRAM) buffer.
+static esp_err_t read_whole_file(const char *path, uint8_t **out_data, long *out_size)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        return ESP_FAIL;
+    }
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (size <= 0) {
+        fclose(f);
+        return ESP_FAIL;
+    }
+    uint8_t *buf = (uint8_t *) heap_caps_malloc((size_t) size, MALLOC_CAP_SPIRAM);
+    if (!buf) {
+        fclose(f);
+        return ESP_ERR_NO_MEM;
+    }
+    size_t read_bytes = fread(buf, 1, (size_t) size, f);
+    fclose(f);
+    if (read_bytes != (size_t) size) {
+        heap_caps_free(buf);
+        return ESP_FAIL;
+    }
+    *out_data = buf;
+    *out_size = size;
+    return ESP_OK;
+}
+
+// Reads just enough of a file to determine its pixel dimensions (bounded
+// read - reuses the same header-scan window as the progressive-JPEG check).
+static esp_err_t peek_file_dimensions(const char *path, image_format_t format, int *out_w,
+                                      int *out_h)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        return ESP_FAIL;
+    }
+    uint8_t *buf = malloc(JPEG_HEADER_SCAN_BYTES);
+    if (!buf) {
+        fclose(f);
+        return ESP_ERR_NO_MEM;
+    }
+    size_t n = fread(buf, 1, JPEG_HEADER_SCAN_BYTES, f);
+    fclose(f);
+    esp_err_t err = image_processor_peek_dimensions(buf, n, format, out_w, out_h);
+    free(buf);
+    return err;
+}
+
+// Whether the frame is currently mounted in portrait as *actually rendered*.
+// display_rotation_deg (not display_orientation, which is only ever sent as
+// an HTTP hint to external URL servers and has no on-device rendering
+// effect) is what display_manager applies at the final blit stage via
+// Paint_NewImage() - a 90/270 correction visually swaps the aspect ratio the
+// viewer sees, regardless of the native panel's fixed pixel layout. Using it
+// here keeps the pairing decision consistent with what the user actually
+// sees, including the case where they only rotated the physical stand.
+static bool wants_portrait_frame_now(void)
+{
+    int rot = config_manager_get_display_rotation_deg() % 360;
+    if (rot < 0) {
+        rot += 360;
+    }
+    return (rot == 90 || rot == 270);
+}
+
+// Composes two source images into a real PNG file under
+// TELEGRAM_DOWNLOAD_DIRECTORY (so the result becomes a normal persisted,
+// already-processed image - showable and available for storage-mode
+// rotation like any other) and returns its path.
+static esp_err_t compose_pair_and_save(const char *path_a, const char *caption_a,
+                                       const char *path_b, const char *caption_b, char *out_path,
+                                       size_t out_path_len)
+{
+    uint8_t *buf_a = NULL, *buf_b = NULL;
+    long size_a = 0, size_b = 0;
+
+    esp_err_t err = read_whole_file(path_a, &buf_a, &size_a);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = read_whole_file(path_b, &buf_b, &size_b);
+    if (err != ESP_OK) {
+        heap_caps_free(buf_a);
+        return err;
+    }
+
+    image_format_t format_a = image_processor_detect_format(path_a);
+    image_format_t format_b = image_processor_detect_format(path_b);
+    dither_algorithm_t algo = processing_settings_get_dithering_algorithm();
+
+    image_process_rgb_result_t result;
+    // Older (first-arrived) image goes in the first slot, newer in the
+    // second, matching arrival order.
+    err = image_processor_compose_pair_to_rgb(buf_a, (size_t) size_a, format_a, buf_b,
+                                              (size_t) size_b, format_b,
+                                              wants_portrait_frame_now(), algo, &result);
+    heap_caps_free(buf_a);
+    heap_caps_free(buf_b);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    const char *overlay = (caption_b && caption_b[0])   ? caption_b
+                         : (caption_a && caption_a[0]) ? caption_a
+                                                        : NULL;
+    if (overlay) {
+        image_processor_draw_caption(result.rgb_data, result.width, result.height, overlay);
+    }
+
+    if (make_unique_telegram_path("png", out_path, out_path_len) != ESP_OK) {
+        heap_caps_free(result.rgb_data);
+        return ESP_FAIL;
+    }
+    err = image_processor_write_rgb_to_png(result.rgb_data, result.width, result.height, out_path);
+    heap_caps_free(result.rgb_data);
+    return err;
+}
+
+// Returns true and fills *out_percent with a valid 0-100 reading only when a
+// battery is actually present and measurable. board_hal_get_battery_percent()
+// returns -1 for "unknown" - notably also on pure-USB power with no battery
+// installed, which must never be treated as "critically low".
+static bool get_valid_battery_percent(int *out_percent)
+{
+    if (!board_hal_is_battery_connected()) {
+        return false;
+    }
+    int percent = board_hal_get_battery_percent();
+    if (percent < 0) {
+        return false;
+    }
+    *out_percent = percent;
+    return true;
+}
+
+// Sends a one-time-per-episode low-battery warning via Telegram, even if
+// this poll had no new updates at all. Debounced via a persisted flag so it
+// fires once per discharge, not on every wake while low; clears once the
+// battery recovers past a small hysteresis margin.
+#define TELEGRAM_LOW_BATTERY_THRESHOLD 20
+#define TELEGRAM_LOW_BATTERY_CLEAR_THRESHOLD 25
+
+static void check_and_warn_low_battery(void)
+{
+    int percent;
+    if (!get_valid_battery_percent(&percent)) {
+        return;
+    }
+    if (percent < TELEGRAM_LOW_BATTERY_THRESHOLD) {
+        if (!config_manager_get_telegram_low_battery_warned()) {
+            char msg[128];
+            snprintf(msg, sizeof(msg),
+                     "[!] Batteriewarnung: Nur noch %d%% verbleibend. Bitte bald aufladen.", percent);
+            telegram_bot_send_message(msg);
+            config_manager_set_telegram_low_battery_warned(true);
+        }
+    } else if (percent >= TELEGRAM_LOW_BATTERY_CLEAR_THRESHOLD) {
+        config_manager_set_telegram_low_battery_warned(false);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Update parsing helpers
+// ----------------------------------------------------------------------------
+
+static cJSON *get_message(cJSON *update_item)
+{
+    return cJSON_GetObjectItem(update_item, "message");
+}
+
+static bool message_from_allowed_chat(cJSON *message, const char *allowed_chat_id)
+{
+    if (!message || !allowed_chat_id || allowed_chat_id[0] == '\0') {
+        return false;
+    }
+    cJSON *chat = cJSON_GetObjectItem(message, "chat");
+    if (!chat) {
+        return false;
+    }
+    cJSON *id_item = cJSON_GetObjectItem(chat, "id");
+    if (!id_item || !cJSON_IsNumber(id_item)) {
+        return false;
+    }
+
+    char id_str[24];
+    snprintf(id_str, sizeof(id_str), "%lld", (long long) id_item->valuedouble);
+    return strcmp(id_str, allowed_chat_id) == 0;
+}
+
+// Plain text messages carry the command in "text"; a photo/document sent with
+// a caption (e.g. a photo captioned "/status") carries it in "caption"
+// instead - Telegram never sets both on the same message, so text wins when
+// present and caption is the fallback. Both the emergency reset scan and the
+// command queue go through this, so a captioned "/telegram_reset" is caught
+// too.
+static const char *get_text(cJSON *message)
+{
+    cJSON *text_item = cJSON_GetObjectItem(message, "text");
+    if (text_item && cJSON_IsString(text_item)) {
+        return text_item->valuestring;
+    }
+    cJSON *caption_item = cJSON_GetObjectItem(message, "caption");
+    if (caption_item && cJSON_IsString(caption_item)) {
+        return caption_item->valuestring;
+    }
+    return NULL;
+}
+
+static void queue_command(const char *text)
+{
+    if (s_pending_command_count >= TELEGRAM_MAX_PENDING_COMMANDS) {
+        ESP_LOGW(TAG, "Pending command queue full, dropping: %s", text);
+        return;
+    }
+    strncpy(s_pending_commands[s_pending_command_count], text, TELEGRAM_COMMAND_MAX_LEN - 1);
+    s_pending_commands[s_pending_command_count][TELEGRAM_COMMAND_MAX_LEN - 1] = '\0';
+    s_pending_command_count++;
+    ESP_LOGI(TAG, "Queued Telegram command: %s", text);
+}
+
+// Forward declaration - defined in the "Command execution" section below
+// (shared with /status) but needed here for the optional wake-up ping.
+static void build_status_message(const char *title, char *out, size_t out_len);
+
+static void send_wake_notification_if_enabled(void)
+{
+    if (!config_manager_get_telegram_wake_notify_enabled()) {
+        return;
+    }
+    char wake_msg[900];
+    build_status_message("PhotoFrame wach", wake_msg, sizeof(wake_msg));
+    telegram_bot_send_message(wake_msg);
+}
+
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
+esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
+{
+    if (!config_manager_telegram_is_configured()) {
+        if (out_result) {
+            *out_result = TELEGRAM_POLL_NOT_CONFIGURED;
+        }
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Ensure the download directory exists (also makes it show up as a
+    // regular album under IMAGE_DIRECTORY for local-storage rotation).
+    mkdir(TELEGRAM_DOWNLOAD_DIRECTORY, 0775);
+
+    int64_t offset = config_manager_get_telegram_last_update_id() + 1;
+    char base_url[256];
+    build_api_url("getUpdates", base_url, sizeof(base_url));
+    char url[350];
+    snprintf(url, sizeof(url), "%s?offset=%lld&timeout=%d&limit=%d", base_url, (long long) offset,
+             TELEGRAM_POLL_TIMEOUT_SEC, TELEGRAM_MAX_UPDATES_PER_POLL);
+
+    char *body = NULL;
+    esp_err_t err = telegram_http_get(
+        url, TELEGRAM_HTTP_TIMEOUT_MS + TELEGRAM_POLL_TIMEOUT_SEC * 1000, &body, NULL);
+    if (err != ESP_OK || !body) {
+        ESP_LOGE(TAG, "getUpdates failed: %s", esp_err_to_name(err));
+        free(body);
+        if (out_result) {
+            *out_result = TELEGRAM_POLL_ERROR;
+        }
+        return ESP_FAIL;
+    }
+
+    cJSON *root = cJSON_Parse(body);
+    free(body);
+    if (!root) {
+        ESP_LOGE(TAG, "getUpdates: failed to parse JSON response");
+        if (out_result) {
+            *out_result = TELEGRAM_POLL_ERROR;
+        }
+        return ESP_FAIL;
+    }
+
+    cJSON *ok_item = cJSON_GetObjectItem(root, "ok");
+    cJSON *result_arr = cJSON_GetObjectItem(root, "result");
+    if (!ok_item || !cJSON_IsTrue(ok_item) || !result_arr || !cJSON_IsArray(result_arr)) {
+        cJSON *desc = cJSON_GetObjectItem(root, "description");
+        ESP_LOGE(TAG, "getUpdates returned an error: %s",
+                 (desc && cJSON_IsString(desc)) ? desc->valuestring : "unknown");
+        cJSON_Delete(root);
+        if (out_result) {
+            *out_result = TELEGRAM_POLL_ERROR;
+        }
+        return ESP_FAIL;
+    }
+
+    // Runs every poll regardless of whether there are new updates, so a low
+    // battery is reported even on an otherwise-quiet wake.
+    check_and_warn_low_battery();
+
+    int count = cJSON_GetArraySize(result_arr);
+    if (count == 0) {
+        ESP_LOGI(TAG, "No new Telegram updates");
+        cJSON_Delete(root);
+        send_wake_notification_if_enabled();
+        if (out_result) {
+            *out_result = TELEGRAM_POLL_OK;
+        }
+        return ESP_OK;
+    }
+
+    const char *allowed_chat_id = config_manager_get_telegram_chat_id();
+    int64_t max_update_id = offset - 1;
+
+    // ---- First pass: highest update_id in the batch + emergency reset scan ----
+    bool reset_found = false;
+    cJSON *item = NULL;
+    cJSON_ArrayForEach(item, result_arr)
+    {
+        cJSON *uid = cJSON_GetObjectItem(item, "update_id");
+        if (uid && cJSON_IsNumber(uid)) {
+            int64_t id = (int64_t) uid->valuedouble;
+            if (id > max_update_id) {
+                max_update_id = id;
+            }
+        }
+
+        cJSON *message = get_message(item);
+        if (!message_from_allowed_chat(message, allowed_chat_id)) {
+            continue;
+        }
+        const char *text = get_text(message);
+        if (text && strncmp(text, TELEGRAM_RESET_COMMAND, strlen(TELEGRAM_RESET_COMMAND)) == 0) {
+            reset_found = true;
+        }
+    }
+
+    if (reset_found) {
+        ESP_LOGW(TAG, "/telegram_reset received - discarding %d update(s), going to sleep", count);
+        config_manager_set_telegram_last_update_id(max_update_id);
+        cJSON_Delete(root);
+        telegram_bot_send_message("[OK] Reset ausgefuehrt, Warteschlange geloescht.");
+        if (out_result) {
+            *out_result = TELEGRAM_POLL_RESET;
+        }
+        return ESP_OK;
+    }
+
+    // Optional wake-up ping, sent every poll (even with no new updates - see
+    // the count==0 branch above) once the batch is confirmed not to be an
+    // emergency reset - kept out of the reset path so a flooded queue still
+    // resets as fast as possible.
+    send_wake_notification_if_enabled();
+
+    // ---- Second pass: download images, pair mismatched orientations inline
+    // (in arrival order, so "newest ready wins" stays consistent whether the
+    // winner is a normal image or a freshly-composed pair), queue commands ----
+    //
+    // These two tracking structs are heap-allocated, not stack locals: the
+    // main task stack is only CONFIG_ESP_MAIN_TASK_STACK_SIZE bytes (6144 on
+    // this project's boards) and the arrays below (320-byte path fields) add
+    // up to well over that on their own - a stack array here would silently
+    // overflow the task stack and crash.
+    typedef struct {
+        char path[320];
+        char caption[TELEGRAM_CAPTION_MAX_LEN];
+        char thumb_file_id[TELEGRAM_FILE_ID_MAX_LEN];
+        char filename[64];
+        int64_t message_id;
+    } telegram_saved_image_t;
+
+#define TELEGRAM_MAX_TRACKED_IMAGES 8
+    telegram_saved_image_t *saved_images = (telegram_saved_image_t *) heap_caps_calloc(
+        TELEGRAM_MAX_TRACKED_IMAGES, sizeof(telegram_saved_image_t), MALLOC_CAP_SPIRAM);
+    int saved_image_count = 0;
+
+    typedef struct {
+        char path_a[320];
+        char path_b[320];
+        char composed_path[320];
+        bool ok;
+    } telegram_pair_result_t;
+#define TELEGRAM_MAX_PAIR_RESULTS (TELEGRAM_MAX_TRACKED_IMAGES / 2 + 1)
+    telegram_pair_result_t *pair_results = (telegram_pair_result_t *) heap_caps_calloc(
+        TELEGRAM_MAX_PAIR_RESULTS, sizeof(telegram_pair_result_t), MALLOC_CAP_SPIRAM);
+    int pair_result_count = 0;
+
+    if (!saved_images || !pair_results) {
+        ESP_LOGE(TAG, "Failed to allocate Telegram poll tracking buffers");
+        heap_caps_free(saved_images);
+        heap_caps_free(pair_results);
+        cJSON_Delete(root);
+        if (out_result) {
+            *out_result = TELEGRAM_POLL_ERROR;
+        }
+        return ESP_ERR_NO_MEM;
+    }
+
+    char display_path[320] = {0};
+    bool have_display_candidate = false;
+    bool combined = false;
+    bool image_attempt_failed = false;
+
+    bool pairing_enabled = config_manager_get_telegram_pairing_enabled();
+    bool wants_portrait = wants_portrait_frame_now();
+
+    cJSON_ArrayForEach(item, result_arr)
+    {
+        cJSON *message = get_message(item);
+        if (!message_from_allowed_chat(message, allowed_chat_id)) {
+            ESP_LOGW(TAG, "Ignoring Telegram update from a disallowed chat");
+            continue;
+        }
+
+        cJSON *photo = cJSON_GetObjectItem(message, "photo");
+        cJSON *document = cJSON_GetObjectItem(message, "document");
+        char downloaded_path[320];
+        char thumb_file_id[TELEGRAM_FILE_ID_MAX_LEN];
+        bool got_image = false;
+
+        if (photo && cJSON_IsArray(photo) && cJSON_GetArraySize(photo) > 0) {
+            got_image = (download_photo_with_fallback(photo, downloaded_path,
+                                                       sizeof(downloaded_path), thumb_file_id,
+                                                       sizeof(thumb_file_id)) == ESP_OK);
+            if (!got_image) {
+                image_attempt_failed = true;
+            }
+        } else if (document && cJSON_IsObject(document)) {
+            got_image = (download_document_image(document, downloaded_path,
+                                                  sizeof(downloaded_path), thumb_file_id,
+                                                  sizeof(thumb_file_id)) == ESP_OK);
+            if (!got_image) {
+                image_attempt_failed = true;
+            }
+        }
+
+        const char *text = get_text(message);
+        // Only a genuine caption becomes a display overlay - not a "/"
+        // command that happens to be attached to the same photo.
+        const char *image_caption = (text && text[0] != '/') ? text : NULL;
+
+        if (got_image) {
+            ESP_LOGI(TAG, "Saved Telegram image: %s", downloaded_path);
+
+            if (saved_image_count < TELEGRAM_MAX_TRACKED_IMAGES) {
+                telegram_saved_image_t *entry = &saved_images[saved_image_count++];
+                strncpy(entry->path, downloaded_path, sizeof(entry->path) - 1);
+                entry->path[sizeof(entry->path) - 1] = '\0';
+                strncpy(entry->caption, image_caption ? image_caption : "",
+                        sizeof(entry->caption) - 1);
+                entry->caption[sizeof(entry->caption) - 1] = '\0';
+                strncpy(entry->thumb_file_id, thumb_file_id, sizeof(entry->thumb_file_id) - 1);
+                entry->thumb_file_id[sizeof(entry->thumb_file_id) - 1] = '\0';
+                const char *fname = strrchr(downloaded_path, '/');
+                fname = fname ? fname + 1 : downloaded_path;
+                strncpy(entry->filename, fname, sizeof(entry->filename) - 1);
+                entry->filename[sizeof(entry->filename) - 1] = '\0';
+                cJSON *mid = cJSON_GetObjectItem(message, "message_id");
+                entry->message_id = (mid && cJSON_IsNumber(mid)) ? (int64_t) mid->valuedouble : 0;
+            } else {
+                ESP_LOGW(TAG, "Too many images in this batch, skipping reply confirmation for %s",
+                         downloaded_path);
+            }
+
+            bool mismatch = false;
+            if (pairing_enabled) {
+                image_format_t fmt = image_processor_detect_format(downloaded_path);
+                if (fmt == IMAGE_FORMAT_PNG || fmt == IMAGE_FORMAT_JPG) {
+                    int w = 0, h = 0;
+                    if (peek_file_dimensions(downloaded_path, fmt, &w, &h) == ESP_OK && w > 0 &&
+                        h > 0) {
+                        mismatch = ((h > w) != wants_portrait);
+                    }
+                }
+            }
+
+            if (!mismatch) {
+                // Orientation already matches the frame (or pairing doesn't
+                // apply to this format) - shows normally, same as before.
+                strncpy(display_path, downloaded_path, sizeof(display_path) - 1);
+                display_path[sizeof(display_path) - 1] = '\0';
+                have_display_candidate = true;
+                combined = false;
+            } else {
+                bool paired = false;
+                if (config_manager_get_telegram_pending_image_count() > 0 &&
+                    pair_result_count < TELEGRAM_MAX_PAIR_RESULTS) {
+                    char pending_path[320], pending_cap[TELEGRAM_CAPTION_MAX_LEN];
+                    config_manager_get_telegram_pending_image_at(
+                        0, pending_path, sizeof(pending_path), pending_cap, sizeof(pending_cap));
+
+                    struct stat st;
+                    if (stat(pending_path, &st) != 0) {
+                        // Vanished (e.g. MemFS wiped by a deep-sleep reboot) -
+                        // drop it; current image becomes the new pending entry
+                        // below.
+                        ESP_LOGW(TAG, "Pending pair image %s vanished, dropping", pending_path);
+                        config_manager_remove_telegram_pending_image_at(0);
+                    } else {
+                        telegram_pair_result_t *pr = &pair_results[pair_result_count++];
+                        strncpy(pr->path_a, pending_path, sizeof(pr->path_a) - 1);
+                        pr->path_a[sizeof(pr->path_a) - 1] = '\0';
+                        strncpy(pr->path_b, downloaded_path, sizeof(pr->path_b) - 1);
+                        pr->path_b[sizeof(pr->path_b) - 1] = '\0';
+
+                        esp_err_t compose_err = compose_pair_and_save(
+                            pending_path, pending_cap, downloaded_path, image_caption,
+                            pr->composed_path, sizeof(pr->composed_path));
+                        pr->ok = (compose_err == ESP_OK);
+                        config_manager_remove_telegram_pending_image_at(0);
+                        paired = true;
+
+                        if (pr->ok) {
+                            ESP_LOGI(TAG, "Composed and saved paired image: %s", pr->composed_path);
+                            strncpy(display_path, pr->composed_path, sizeof(display_path) - 1);
+                            display_path[sizeof(display_path) - 1] = '\0';
+                            have_display_candidate = true;
+                            combined = true;
+                        } else {
+                            ESP_LOGE(TAG, "Failed to compose pair (%s + %s): %s", pending_path,
+                                     downloaded_path, esp_err_to_name(compose_err));
+                        }
+                    }
+                }
+                if (!paired) {
+                    config_manager_add_telegram_pending_image(downloaded_path,
+                                                              image_caption ? image_caption : "");
+                }
+            }
+        }
+
+        if (text && text[0] == '/') {
+            queue_command(text);
+        }
+    }
+
+    cJSON_Delete(root);
+
+    bool displayed = false;
+    esp_err_t disp_err = ESP_OK;
+    if (have_display_candidate) {
+        // A composed pair already has its caption baked in; a normal image
+        // still needs its own caption applied at display time.
+        const char *caption_for_display = NULL;
+        if (!combined) {
+            for (int i = saved_image_count - 1; i >= 0; i--) {
+                if (strcmp(saved_images[i].path, display_path) == 0) {
+                    caption_for_display = saved_images[i].caption[0] ? saved_images[i].caption : NULL;
+                    break;
+                }
+            }
+        }
+        disp_err = process_and_display_telegram_image(display_path, caption_for_display);
+        displayed = (disp_err == ESP_OK);
+    } else if (image_attempt_failed) {
+        telegram_bot_send_message(
+            "[FEHLER] Telegram-Bild konnte nicht geladen werden\n"
+            "(zu gross, nicht unterstuetztes Format, oder nur als progressives JPEG "
+            "verfuegbar). Bitte kleineres Bild oder als Datei senden.");
+    }
+
+    // Per-image "saved" confirmations, threaded as a reply to the original
+    // message and (where Telegram gave us a thumbnail file_id) attaching the
+    // smallest available photo size - already hosted by Telegram, so no
+    // re-upload is needed.
+    for (int i = 0; i < saved_image_count; i++) {
+        telegram_saved_image_t *entry = &saved_images[i];
+        char caption_text[192];
+
+        int pair_index = -1;
+        for (int j = 0; j < pair_result_count; j++) {
+            if (strcmp(pair_results[j].path_a, entry->path) == 0 ||
+                strcmp(pair_results[j].path_b, entry->path) == 0) {
+                pair_index = j;
+                break;
+            }
+        }
+
+        bool still_pending = false;
+        int pending_count = config_manager_get_telegram_pending_image_count();
+        for (int j = 0; j < pending_count && !still_pending; j++) {
+            char p[320];
+            if (config_manager_get_telegram_pending_image_at(j, p, sizeof(p), NULL, 0) &&
+                strcmp(p, entry->path) == 0) {
+                still_pending = true;
+            }
+        }
+
+        bool this_is_shown = have_display_candidate && strcmp(entry->path, display_path) == 0;
+        // entry->path is always one of the two SOURCE images, never the
+        // synthesized composed_path itself - so this compares against the
+        // pair's own composed_path, not entry->path/this_is_shown.
+        bool this_pair_is_shown = (pair_index >= 0 && pair_results[pair_index].ok && combined &&
+                                   have_display_candidate &&
+                                   strcmp(pair_results[pair_index].composed_path, display_path) ==
+                                       0);
+
+        if (this_pair_is_shown) {
+            snprintf(caption_text, sizeof(caption_text),
+                     "[OK] Gespeichert & mit vorherigem Bild kombiniert angezeigt\n%.80s",
+                     entry->filename);
+        } else if (pair_index >= 0 && pair_results[pair_index].ok) {
+            snprintf(caption_text, sizeof(caption_text),
+                     "[OK] Gespeichert & kombiniert im Album (nicht angezeigt)\n%.60s",
+                     entry->filename);
+        } else if (pair_index >= 0) {
+            snprintf(caption_text, sizeof(caption_text),
+                     "[!] Gespeichert, Kombination fehlgeschlagen\n%.80s", entry->filename);
+        } else if (this_is_shown && displayed) {
+            snprintf(caption_text, sizeof(caption_text), "[OK] Gespeichert & angezeigt\n%.100s",
+                     entry->filename);
+        } else if (this_is_shown) {
+            snprintf(caption_text, sizeof(caption_text),
+                     "[!] Gespeichert (%.80s)\nAnzeige fehlgeschlagen: %.30s", entry->filename,
+                     esp_err_to_name(disp_err));
+        } else if (still_pending) {
+            snprintf(caption_text, sizeof(caption_text),
+                     "[OK] Gespeichert, wartet auf Hoch-/Querformat-Partnerbild\n%.100s",
+                     entry->filename);
+        } else {
+            snprintf(caption_text, sizeof(caption_text), "[OK] Gespeichert (Warteschlange)\n%.100s",
+                     entry->filename);
+        }
+
+        if (entry->thumb_file_id[0] != '\0') {
+            telegram_bot_send_photo_reply(entry->thumb_file_id, caption_text, entry->message_id);
+        } else {
+            telegram_bot_send_message_reply(caption_text, entry->message_id);
+        }
+    }
+
+    heap_caps_free(saved_images);
+    heap_caps_free(pair_results);
+
+    config_manager_set_telegram_last_update_id(max_update_id);
+
+    if (out_result) {
+        *out_result = TELEGRAM_POLL_OK;
+    }
+    return ESP_OK;
+}
+
+// ----------------------------------------------------------------------------
+// Command execution
+// ----------------------------------------------------------------------------
+
+static const char *reset_reason_string(void)
+{
+    switch (esp_reset_reason()) {
+    case ESP_RST_POWERON:
+        return "Power-On";
+    case ESP_RST_SW:
+        return "Software-Reset";
+    case ESP_RST_PANIC:
+        return "Exception/Panic";
+    case ESP_RST_INT_WDT:
+        return "Interrupt-Watchdog";
+    case ESP_RST_TASK_WDT:
+        return "Task-Watchdog";
+    case ESP_RST_WDT:
+        return "Watchdog";
+    case ESP_RST_DEEPSLEEP:
+        return "Deep-Sleep-Wake";
+    case ESP_RST_BROWNOUT:
+        return "Brownout";
+    default:
+        return "Unbekannt";
+    }
+}
+
+static void format_battery(char *out, size_t out_len)
+{
+    int percent;
+    if (!get_valid_battery_percent(&percent)) {
+        snprintf(out, out_len, board_hal_is_usb_connected() ? "USB verbunden (kein Akku erkannt)"
+                                                             : "unbekannt");
+        return;
+    }
+    int mv = board_hal_get_battery_voltage();
+    snprintf(out, out_len, "%d%% (%d mV)%s%s", percent, mv, board_hal_is_charging() ? ", laedt" : "",
+             board_hal_is_usb_connected() ? ", USB verbunden" : "");
+}
+
+static void format_free_storage(char *out, size_t out_len)
+{
+    storage_type_t type = storage_get_type();
+    uint64_t total = 0, free_bytes = 0;
+    bool have = false;
+
+    if (type == STORAGE_TYPE_SDCARD) {
+        uint64_t t = 0, f = 0;
+        if (esp_vfs_fat_info(FS_MOUNT_POINT, &t, &f) == ESP_OK) {
+            total = t;
+            free_bytes = f;
+            have = true;
+        }
+    } else if (type == STORAGE_TYPE_LITTLEFS) {
+        size_t t = 0, u = 0;
+        if (esp_littlefs_info(LITTLEFS_PARTITION_LABEL, &t, &u) == ESP_OK) {
+            total = t;
+            free_bytes = (t > u) ? (t - u) : 0;
+            have = true;
+        }
+    }
+
+    if (!have) {
+        snprintf(out, out_len, "n/a");
+        return;
+    }
+    int percent = (total > 0) ? (int) ((free_bytes * 100ULL) / total) : 0;
+    snprintf(out, out_len, "%.1f/%.1f MB frei (%d%%)", free_bytes / (1024.0 * 1024.0),
+             total / (1024.0 * 1024.0), percent);
+}
+
+static void format_heap(char *out, size_t out_len)
+{
+    size_t free_bytes = heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
+    size_t total_bytes = heap_caps_get_total_size(MALLOC_CAP_DEFAULT);
+    int percent = (total_bytes > 0) ? (int) ((free_bytes * 100ULL) / total_bytes) : 0;
+    snprintf(out, out_len, "%.1f/%.1f MB frei (%d%%)", free_bytes / (1024.0 * 1024.0),
+             total_bytes / (1024.0 * 1024.0), percent);
+}
+
+static void format_toggles(char *out, size_t out_len)
+{
+    snprintf(out, out_len,
+             "[%c] Pairing (Hoch-/Quer-Kombi)\n"
+             "[%c] Deep Sleep\n"
+             "[%c] Auto-Rotate\n"
+             "[%c] Wach-Auf-Meldung\n"
+             "[%c] Fehler-Overlay\n"
+             "[%c] WLAN-Performance",
+             config_manager_get_telegram_pairing_enabled() ? 'x' : ' ',
+             config_manager_get_deep_sleep_enabled() ? 'x' : ' ',
+             config_manager_get_auto_rotate() ? 'x' : ' ',
+             config_manager_get_telegram_wake_notify_enabled() ? 'x' : ' ',
+             config_manager_get_error_overlay_enabled() ? 'x' : ' ',
+             config_manager_get_wifi_performance_mode_enabled() ? 'x' : ' ');
+}
+
+static void format_rotation_schedule(char *out, size_t out_len)
+{
+    if (!config_manager_get_auto_rotate()) {
+        snprintf(out, out_len, "Auto-Rotate deaktiviert");
+        return;
+    }
+    int count = config_manager_get_cron_rule_count();
+    if (count == 0) {
+        snprintf(out, out_len, "kein Zeitplan konfiguriert");
+        return;
+    }
+    size_t off = 0;
+    out[0] = '\0';
+    for (int i = 0; i < count && off < out_len; i++) {
+        const char *rule = config_manager_get_cron_rule(i);
+        if (!rule) {
+            continue;
+        }
+        int n = snprintf(out + off, out_len - off, "%s%s", i ? ", " : "", rule);
+        if (n < 0 || (size_t) n >= out_len - off) {
+            break;
+        }
+        off += (size_t) n;
+    }
+}
+
+// Shared by /status and the optional wake-up notification - `title` is the
+// only thing that differs between the two use sites.
+static void build_status_message(const char *title, char *out, size_t out_len)
+{
+    const esp_app_desc_t *app_desc = esp_app_get_description();
+
+    char battery[64];
+    format_battery(battery, sizeof(battery));
+
+    char ip_str[16] = "n/a";
+    wifi_manager_get_ip(ip_str, sizeof(ip_str));
+
+    char storage[64];
+    format_free_storage(storage, sizeof(storage));
+
+    char heap[64];
+    format_heap(heap, sizeof(heap));
+
+    char schedule[160];
+    format_rotation_schedule(schedule, sizeof(schedule));
+
+    char toggles[224];
+    format_toggles(toggles, sizeof(toggles));
+
+    const char *ssid = config_manager_get_wifi_ssid();
+
+    snprintf(out, out_len,
+             "=== %s ===\n"
+             "Firmware: %s (%s)\n"
+             "Neustartgrund: %s\n"
+             "\n"
+             "Batterie: %s\n"
+             "WLAN: %s (%s)\n"
+             "\n"
+             "Speicher: %s\n"
+             "Heap: %s\n"
+             "\n"
+             "Rotations-Zeitplan: %s\n"
+             "\n"
+             "Einstellungen:\n"
+             "%s",
+             title, app_desc->version, BOARD_HAL_NAME, reset_reason_string(), battery,
+             ssid ? ssid : "n/a", ip_str, storage, heap, schedule, toggles);
+}
+
+// Executes one queued "/"-command and sends a sendMessage reply. Strips an
+// optional "@BotName" suffix (Telegram appends it in group chats) and splits
+// off any argument text after the command token (e.g. "/rotate_cron 0 */12 *").
+static void execute_command(const char *raw_text)
+{
+    char full[TELEGRAM_COMMAND_MAX_LEN];
+    strncpy(full, raw_text, sizeof(full) - 1);
+    full[sizeof(full) - 1] = '\0';
+
+    char *args = NULL;
+    char *space = strpbrk(full, " \t\n@");
+    if (space) {
+        bool had_at = (*space == '@');
+        *space = '\0';
+        // Plain space: `space` itself is the delimiter before the args.
+        // '@BotName' suffix: skip past the username to find the real
+        // delimiter, if any, before the args.
+        char *delim = had_at ? strpbrk(space + 1, " \t\n") : space;
+        if (delim) {
+            args = delim + 1;
+            while (*args == ' ' || *args == '\t') {
+                args++;
+            }
+            if (*args == '\0') {
+                args = NULL;
+            }
+        }
+    }
+    const char *cmd = full;
+
+    ESP_LOGI(TAG, "Executing Telegram command: %s%s%s", cmd, args ? " " : "", args ? args : "");
+
+    if (strcmp(cmd, "/status") == 0) {
+        char msg[900];
+        build_status_message("PhotoFrame Status", msg, sizeof(msg));
+        telegram_bot_send_message(msg);
+    } else if (strcmp(cmd, "/clear") == 0) {
+        esp_err_t err = display_manager_clear();
+        telegram_bot_send_message(err == ESP_OK ? "[OK] Anzeige geloescht."
+                                                 : "[FEHLER] Anzeige loeschen fehlgeschlagen.");
+    } else if (strcmp(cmd, "/restart") == 0) {
+        telegram_bot_send_message("[OK] Neustart wird durchgefuehrt...");
+        vTaskDelay(pdMS_TO_TICKS(500));  // give the HTTP send a moment to flush
+        esp_restart();
+        // Does not return.
+    } else if (strcmp(cmd, "/pairing") == 0) {
+        bool enabled = !config_manager_get_telegram_pairing_enabled();
+        config_manager_set_telegram_pairing_enabled(enabled);
+        if (!enabled) {
+            // Turning pairing off drops the tracking queue only - the files
+            // themselves stay on storage, nothing is deleted.
+            config_manager_clear_telegram_pending_images();
+        }
+        char msg[160];
+        snprintf(msg, sizeof(msg),
+                 "[%c] Hoch-/Querformat-Kombination\n"
+                 "Aktuelle Rahmenausrichtung: %s",
+                 enabled ? 'x' : ' ',
+                 wants_portrait_frame_now() ? "Hochformat" : "Querformat");
+        telegram_bot_send_message(msg);
+    } else if (strcmp(cmd, "/rotate_cron") == 0) {
+        if (!args) {
+            telegram_bot_send_message(
+                "[i] Verwendung: /rotate_cron <Minute Stunde Wochentag>\n"
+                "Beispiel: /rotate_cron 0 */12 *");
+        } else {
+            cron_rule_t tmp;
+            if (!cron_parse(args, &tmp)) {
+                char msg[192];
+                snprintf(msg, sizeof(msg), "[FEHLER] Ungueltiger Cron-Ausdruck: %.100s", args);
+                telegram_bot_send_message(msg);
+            } else {
+                const char *one[1] = {args};
+                config_manager_set_cron_rules(one, 1);
+                power_manager_reset_rotate_timer();
+                char msg[192];
+                snprintf(msg, sizeof(msg), "[OK] Rotations-Zeitplan gesetzt: %.100s", args);
+                telegram_bot_send_message(msg);
+            }
+        }
+    } else if (strcmp(cmd, "/deep_sleep") == 0) {
+        if (args && strcasecmp(args, "on") == 0) {
+            power_manager_set_deep_sleep_enabled(true);
+            telegram_bot_send_message("[x] Deep Sleep aktiviert.");
+        } else if (args && strcasecmp(args, "off") == 0) {
+            power_manager_set_deep_sleep_enabled(false);
+            telegram_bot_send_message("[ ] Deep Sleep deaktiviert.");
+        } else {
+            telegram_bot_send_message("[i] Verwendung: /deep_sleep on|off");
+        }
+    } else if (strcmp(cmd, "/auto_rotate") == 0) {
+        if (args && strcasecmp(args, "on") == 0) {
+            config_manager_set_auto_rotate(true);
+            power_manager_reset_rotate_timer();
+            telegram_bot_send_message("[x] Auto-Rotate aktiviert.");
+        } else if (args && strcasecmp(args, "off") == 0) {
+            config_manager_set_auto_rotate(false);
+            telegram_bot_send_message("[ ] Auto-Rotate deaktiviert.");
+        } else {
+            telegram_bot_send_message("[i] Verwendung: /auto_rotate on|off");
+        }
+    } else if (strcmp(cmd, "/wake_notify") == 0) {
+        if (args && strcasecmp(args, "on") == 0) {
+            config_manager_set_telegram_wake_notify_enabled(true);
+            telegram_bot_send_message("[x] Wach-Auf-Benachrichtigung aktiviert.");
+        } else if (args && strcasecmp(args, "off") == 0) {
+            config_manager_set_telegram_wake_notify_enabled(false);
+            telegram_bot_send_message("[ ] Wach-Auf-Benachrichtigung deaktiviert.");
+        } else {
+            telegram_bot_send_message("[i] Verwendung: /wake_notify on|off");
+        }
+    } else if (strcmp(cmd, "/error_overlay") == 0) {
+        if (args && strcasecmp(args, "on") == 0) {
+            config_manager_set_error_overlay_enabled(true);
+            telegram_bot_send_message("[x] Fehler-Overlay auf dem Display aktiviert.");
+        } else if (args && strcasecmp(args, "off") == 0) {
+            config_manager_set_error_overlay_enabled(false);
+            telegram_bot_send_message("[ ] Fehler-Overlay auf dem Display deaktiviert.");
+        } else {
+            telegram_bot_send_message("[i] Verwendung: /error_overlay on|off");
+        }
+    } else if (strcmp(cmd, "/wifi_perf") == 0) {
+        if (args && strcasecmp(args, "on") == 0) {
+            config_manager_set_wifi_performance_mode_enabled(true);
+            telegram_bot_send_message(
+                "[x] WLAN-Performance-Modus aktiviert\n(automatische Umschaltung je nach Kontext).");
+        } else if (args && strcasecmp(args, "off") == 0) {
+            config_manager_set_wifi_performance_mode_enabled(false);
+            telegram_bot_send_message(
+                "[ ] WLAN-Performance-Modus deaktiviert\n(immer Stromsparmodus, langsamere Web-UI).");
+        } else {
+            telegram_bot_send_message("[i] Verwendung: /wifi_perf on|off");
+        }
+    } else if (strcmp(cmd, "/help") == 0) {
+        telegram_bot_send_message(
+            "=== Verfuegbare Befehle ===\n"
+            "\n"
+            "Status:\n"
+            "/status - Status, Batterie, WLAN, Speicher, Einstellungen\n"
+            "\n"
+            "Anzeige:\n"
+            "/clear - Anzeige loeschen\n"
+            "/restart - Neustart des Bilderrahmens\n"
+            "/pairing - Hoch-/Querformat-Kombination umschalten\n"
+            "\n"
+            "Einstellungen (jeweils on|off, ohne Argument = Hilfe):\n"
+            "/rotate_cron <M H Wochentag> - Rotations-Zeitplan setzen\n"
+            "/deep_sleep on|off\n"
+            "/auto_rotate on|off\n"
+            "/wake_notify on|off - Status-Ping bei jedem Aufwachen\n"
+            "/error_overlay on|off - Fehlerhinweis auf dem Display\n"
+            "/wifi_perf on|off - WLAN-Performance-Modus\n"
+            "\n"
+            "Notfall:\n"
+            "/telegram_reset - Warteschlange sofort leeren\n"
+            "\n"
+            "Bilder koennen als Foto oder als Datei gesendet werden. Eine "
+            "Bildunterschrift wird als Overlay auf dem Bild angezeigt (ausser "
+            "sie beginnt mit \"/\").");
+    } else {
+        char msg[192];
+        snprintf(msg, sizeof(msg), "[FEHLER] Unbekannter Befehl: %s\nSiehe /help fuer eine Uebersicht.",
+                 cmd);
+        telegram_bot_send_message(msg);
+    }
+}
+
+void telegram_bot_run_pending_commands(void)
+{
+    for (int i = 0; i < s_pending_command_count; i++) {
+        execute_command(s_pending_commands[i]);
+    }
+    s_pending_command_count = 0;
+}

--- a/main/telegram_bot.c
+++ b/main/telegram_bot.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "album_manager.h"
+#include "battery_history.h"
 #include "board_hal.h"
 #include "cJSON.h"
 #include "config.h"
@@ -867,6 +868,137 @@ static esp_err_t read_whole_file(const char *path, uint8_t **out_data, long *out
     return ESP_OK;
 }
 
+// Uploads a local file as a brand-new Telegram photo (multipart/form-data
+// POST to sendPhoto) - unlike telegram_bot_send_photo_reply() above, which
+// re-references an existing Telegram-hosted file_id, this actually uploads
+// bytes Telegram has never seen (e.g. a locally generated thumbnail). Kept
+// to small files (thumbnails) - buffers the whole multipart body in SPIRAM
+// rather than streaming, which keeps this simple and is fine at that size.
+static esp_err_t telegram_bot_send_photo_file(const char *file_path, const char *caption)
+{
+    if (!config_manager_telegram_is_configured() || !file_path) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    uint8_t *file_data = NULL;
+    long file_size = 0;
+    if (read_whole_file(file_path, &file_data, &file_size) != ESP_OK) {
+        ESP_LOGW(TAG, "send_photo_file: failed to read %s", file_path);
+        return ESP_FAIL;
+    }
+
+    const char *boundary = "----ESP32PhotoFrameBoundary";
+    const char *filename = strrchr(file_path, '/');
+    filename = filename ? filename + 1 : file_path;
+    const char *chat_id = config_manager_get_telegram_chat_id();
+
+    char part1[512];
+    int part1_len =
+        snprintf(part1, sizeof(part1),
+                 "--%s\r\n"
+                 "Content-Disposition: form-data; name=\"chat_id\"\r\n\r\n%s\r\n"
+                 "--%s\r\n"
+                 "Content-Disposition: form-data; name=\"caption\"\r\n\r\n%.900s\r\n"
+                 "--%s\r\n"
+                 "Content-Disposition: form-data; name=\"photo\"; filename=\"%.100s\"\r\n"
+                 "Content-Type: image/jpeg\r\n\r\n",
+                 boundary, chat_id ? chat_id : "", boundary, caption ? caption : "", boundary,
+                 filename);
+    if (part1_len < 0 || (size_t) part1_len >= sizeof(part1)) {
+        heap_caps_free(file_data);
+        return ESP_FAIL;
+    }
+
+    char part2[64];
+    int part2_len = snprintf(part2, sizeof(part2), "\r\n--%s--\r\n", boundary);
+
+    size_t total_len = (size_t) part1_len + (size_t) file_size + (size_t) part2_len;
+    uint8_t *multipart_body = (uint8_t *) heap_caps_malloc(total_len, MALLOC_CAP_SPIRAM);
+    if (!multipart_body) {
+        heap_caps_free(file_data);
+        return ESP_ERR_NO_MEM;
+    }
+    memcpy(multipart_body, part1, (size_t) part1_len);
+    memcpy(multipart_body + part1_len, file_data, (size_t) file_size);
+    memcpy(multipart_body + part1_len + file_size, part2, (size_t) part2_len);
+    heap_caps_free(file_data);
+
+    char url[256];
+    build_api_url("sendPhoto", url, sizeof(url));
+    char content_type[64];
+    snprintf(content_type, sizeof(content_type), "multipart/form-data; boundary=%s", boundary);
+
+    esp_err_t result = ESP_FAIL;
+    for (int attempt = 1; attempt <= TELEGRAM_HTTP_RETRY_COUNT; attempt++) {
+        if (attempt > 1) {
+            ESP_LOGW(TAG, "Retrying sendPhoto upload (%d/%d) after %d ms...", attempt,
+                     TELEGRAM_HTTP_RETRY_COUNT, TELEGRAM_HTTP_RETRY_DELAY_MS);
+            vTaskDelay(pdMS_TO_TICKS(TELEGRAM_HTTP_RETRY_DELAY_MS));
+        }
+
+        esp_http_client_config_t config = {
+            .url = url,
+            .method = HTTP_METHOD_POST,
+            .timeout_ms = TELEGRAM_HTTP_TIMEOUT_MS,
+            .crt_bundle_attach = esp_crt_bundle_attach,
+        };
+        esp_http_client_handle_t client = esp_http_client_init(&config);
+        if (!client) {
+            continue;
+        }
+
+        esp_http_client_set_header(client, "Content-Type", content_type);
+        esp_http_client_set_post_field(client, (const char *) multipart_body, (int) total_len);
+
+        esp_err_t err = esp_http_client_perform(client);
+        int status = esp_http_client_get_status_code(client);
+        esp_http_client_cleanup(client);
+
+        if (err != ESP_OK || status != 200) {
+            ESP_LOGW(TAG, "sendPhoto upload failed (err=%s, status=%d)", esp_err_to_name(err),
+                     status);
+            continue;
+        }
+        result = ESP_OK;
+        break;
+    }
+
+    heap_caps_free(multipart_body);
+    return result;
+}
+
+// Notifies Telegram about an image that was displayed via fallback album
+// rotation (i.e. NOT from a Telegram push) - see
+// config_manager_get_telegram_rotation_notify_enabled(). Sends the image's
+// thumbnail sidecar if one exists (much smaller/faster to upload than the
+// full display-resolution image), falling back to the full image otherwise.
+esp_err_t telegram_bot_notify_fallback_image(const char *image_path)
+{
+    if (!image_path || image_path[0] == '\0') {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    char thumb_path[320];
+    strncpy(thumb_path, image_path, sizeof(thumb_path) - 1);
+    thumb_path[sizeof(thumb_path) - 1] = '\0';
+    char *ext = strrchr(thumb_path, '.');
+    const char *send_path = image_path;
+    if (ext && (size_t) (ext - thumb_path) + 4 < sizeof(thumb_path)) {
+        strcpy(ext, ".jpg");
+        struct stat st;
+        if (strcmp(thumb_path, image_path) != 0 && stat(thumb_path, &st) == 0) {
+            send_path = thumb_path;
+        }
+    }
+
+    const char *fname = strrchr(image_path, '/');
+    fname = fname ? fname + 1 : image_path;
+    char caption[192];
+    snprintf(caption, sizeof(caption), "[i] Auto-rotate (no new Telegram image): %.100s", fname);
+
+    return telegram_bot_send_photo_file(send_path, caption);
+}
+
 // Reads just enough of a file to determine its pixel dimensions (bounded
 // read - reuses the same header-scan window as the progressive-JPEG check).
 // Whether the frame is currently mounted in portrait as *actually rendered*.
@@ -1562,14 +1694,16 @@ static void format_toggles(char *out, size_t out_len)
              "[%c] Wake notification\n"
              "[%c] Error overlay\n"
              "[%c] WiFi performance\n"
-             "[%c] Rotation pairing (random mode only)",
+             "[%c] Rotation pairing (random mode only)\n"
+             "[%c] Rotation notify (thumbnail on fallback display)",
              config_manager_get_telegram_pairing_enabled() ? 'x' : ' ',
              config_manager_get_deep_sleep_enabled() ? 'x' : ' ',
              config_manager_get_auto_rotate() ? 'x' : ' ',
              config_manager_get_telegram_wake_notify_enabled() ? 'x' : ' ',
              config_manager_get_error_overlay_enabled() ? 'x' : ' ',
              config_manager_get_wifi_performance_mode_enabled() ? 'x' : ' ',
-             config_manager_get_rotation_pairing_enabled() ? 'x' : ' ');
+             config_manager_get_rotation_pairing_enabled() ? 'x' : ' ',
+             config_manager_get_telegram_rotation_notify_enabled() ? 'x' : ' ');
 }
 
 static void format_rotation_schedule(char *out, size_t out_len)
@@ -1600,12 +1734,29 @@ static void format_rotation_schedule(char *out, size_t out_len)
 
 // Shared by /status and the optional wake-up notification - `title` is the
 // only thing that differs between the two use sites.
+static void format_battery_estimate(char *out, size_t out_len)
+{
+    double days;
+    if (!battery_history_estimate_days_remaining(&days)) {
+        snprintf(out, out_len, "not enough history yet");
+        return;
+    }
+    if (days <= 0) {
+        snprintf(out, out_len, "already at or below %d%%", BATTERY_HISTORY_TARGET_PERCENT);
+    } else {
+        snprintf(out, out_len, "~%.1f days until %d%%", days, BATTERY_HISTORY_TARGET_PERCENT);
+    }
+}
+
 static void build_status_message(const char *title, char *out, size_t out_len)
 {
     const esp_app_desc_t *app_desc = esp_app_get_description();
 
     char battery[64];
     format_battery(battery, sizeof(battery));
+
+    char battery_estimate[64];
+    format_battery_estimate(battery_estimate, sizeof(battery_estimate));
 
     char ip_str[16] = "n/a";
     wifi_manager_get_ip(ip_str, sizeof(ip_str));
@@ -1619,7 +1770,7 @@ static void build_status_message(const char *title, char *out, size_t out_len)
     char schedule[160];
     format_rotation_schedule(schedule, sizeof(schedule));
 
-    char toggles[224];
+    char toggles[320];
     format_toggles(toggles, sizeof(toggles));
 
     const char *ssid = config_manager_get_wifi_ssid();
@@ -1630,6 +1781,7 @@ static void build_status_message(const char *title, char *out, size_t out_len)
              "Reset reason: %s\n"
              "\n"
              "Battery: %s\n"
+             "Battery estimate: %s\n"
              "WiFi: %s (%s)\n"
              "\n"
              "Storage: %s\n"
@@ -1640,7 +1792,7 @@ static void build_status_message(const char *title, char *out, size_t out_len)
              "Settings:\n"
              "%s",
              title, app_desc->version, BOARD_HAL_NAME, reset_reason_string(), battery,
-             ssid ? ssid : "n/a", ip_str, storage, heap, schedule, toggles);
+             battery_estimate, ssid ? ssid : "n/a", ip_str, storage, heap, schedule, toggles);
 }
 
 // Executes one queued "/"-command and sends a sendMessage reply. Strips an
@@ -1788,6 +1940,19 @@ static void execute_command(const char *raw_text)
         } else {
             telegram_bot_send_message("[i] Usage: /rotation_pairing on|off");
         }
+    } else if (strcmp(cmd, "/rotation_notify") == 0) {
+        if (args && strcasecmp(args, "on") == 0) {
+            config_manager_set_telegram_rotation_notify_enabled(true);
+            telegram_bot_send_message(
+                "[x] Fallback-rotation notification enabled\n"
+                "(sends a thumbnail whenever a wake shows an image that didn't come from "
+                "Telegram).");
+        } else if (args && strcasecmp(args, "off") == 0) {
+            config_manager_set_telegram_rotation_notify_enabled(false);
+            telegram_bot_send_message("[ ] Fallback-rotation notification disabled.");
+        } else {
+            telegram_bot_send_message("[i] Usage: /rotation_notify on|off");
+        }
     } else if (strcmp(cmd, "/list_albums") == 0) {
         char **albums = NULL;
         int count = 0;
@@ -1880,6 +2045,8 @@ static void execute_command(const char *raw_text)
             "/wifi_perf on|off - WiFi performance mode\n"
             "/rotation_pairing on|off - Combine mismatched-orientation images\n"
             "  during auto-rotation (random mode only, no effect in sequential mode)\n"
+            "/rotation_notify on|off - Send a thumbnail when a wake displays an\n"
+            "  image that didn't come from Telegram (i.e. fallback rotation)\n"
             "\n"
             "Emergency:\n"
             "/telegram_reset - Clear the queue immediately\n"

--- a/main/telegram_bot.c
+++ b/main/telegram_bot.c
@@ -537,23 +537,73 @@ static esp_err_t make_unique_telegram_path(const char *ext, char *out, size_t ou
     return ESP_FAIL;
 }
 
-// Downloads a Telegram "photo" (array of re-encoded resolutions, ascending
-// size) trying the largest first. Falls back to the next smaller size when
-// the current one is too large for getFile, fails to download, or turns out
-// to be a progressive JPEG we can't decode - until one succeeds or the
-// smallest size has also failed.
+// Telegram documents the "photo" array only as "available sizes of the
+// photo" - in practice every client sends it smallest-to-largest, but that
+// ordering isn't a formal API guarantee, so this ranks entries by their own
+// width*height instead of trusting array position. Caps the number of sizes
+// considered; Telegram sends at most a handful (thumbnail/medium/large/
+// original) per photo.
+#define TELEGRAM_MAX_PHOTO_SIZES 8
+
+// Downloads a Telegram "photo" (multiple re-encoded resolutions of the same
+// image), trying the largest by pixel area first. Falls back to the next
+// smaller size when the current one is too large for getFile, fails to
+// download, or turns out to be a progressive JPEG we can't decode - until one
+// succeeds or every size has also failed.
 //
 // out_thumb_file_id is filled with the smallest available size's file_id
 // regardless of which size was actually saved - Telegram already hosts it,
 // so it can be echoed straight back via sendPhoto as a lightweight "saved"
 // confirmation without re-uploading anything.
+//
+// out_largest_file_id is filled with the LARGEST available size's file_id,
+// also regardless of which size was actually downloaded here - the largest
+// is often the one size that turns out to be an undecodable progressive
+// JPEG, in which case this function itself falls back to a smaller one for
+// display. Callers that want the best possible archival copy (not a
+// decode-capable one) can re-fetch this file_id directly; no decode is
+// needed to just save raw bytes to disk.
 static esp_err_t download_photo_with_fallback(cJSON *photo_array, char *out_path,
                                                size_t out_path_len, char *out_thumb_file_id,
-                                               size_t out_thumb_file_id_len)
+                                               size_t out_thumb_file_id_len,
+                                               char *out_largest_file_id,
+                                               size_t out_largest_file_id_len)
 {
+    int n = cJSON_GetArraySize(photo_array);
+    if (n <= 0) {
+        return ESP_FAIL;
+    }
+    if (n > TELEGRAM_MAX_PHOTO_SIZES) {
+        n = TELEGRAM_MAX_PHOTO_SIZES;
+    }
+
+    // order[0] = largest by area, order[n-1] = smallest.
+    int order[TELEGRAM_MAX_PHOTO_SIZES];
+    long long area[TELEGRAM_MAX_PHOTO_SIZES];
+    for (int i = 0; i < n; i++) {
+        order[i] = i;
+        cJSON *size_obj = cJSON_GetArrayItem(photo_array, i);
+        cJSON *w_item = size_obj ? cJSON_GetObjectItem(size_obj, "width") : NULL;
+        cJSON *h_item = size_obj ? cJSON_GetObjectItem(size_obj, "height") : NULL;
+        long long w = (w_item && cJSON_IsNumber(w_item)) ? (long long) w_item->valuedouble : 0;
+        long long h = (h_item && cJSON_IsNumber(h_item)) ? (long long) h_item->valuedouble : 0;
+        area[i] = w * h;
+    }
+    // Simple insertion sort (n is at most a handful of entries).
+    for (int i = 1; i < n; i++) {
+        int cur = order[i];
+        long long cur_area = area[cur];
+        int j = i - 1;
+        while (j >= 0 && area[order[j]] < cur_area) {
+            order[j + 1] = order[j];
+            j--;
+        }
+        order[j + 1] = cur;
+    }
+
     if (out_thumb_file_id && out_thumb_file_id_len > 0) {
         out_thumb_file_id[0] = '\0';
-        cJSON *smallest = cJSON_GetArrayItem(photo_array, 0);
+        cJSON *smallest = cJSON_GetArrayItem(photo_array, order[n - 1]);
         cJSON *smallest_id = smallest ? cJSON_GetObjectItem(smallest, "file_id") : NULL;
         if (smallest_id && cJSON_IsString(smallest_id)) {
             strncpy(out_thumb_file_id, smallest_id->valuestring, out_thumb_file_id_len - 1);
@@ -561,9 +611,19 @@ static esp_err_t download_photo_with_fallback(cJSON *photo_array, char *out_path
         }
     }
 
-    int n = cJSON_GetArraySize(photo_array);
-    for (int i = n - 1; i >= 0; i--) {
-        cJSON *size_obj = cJSON_GetArrayItem(photo_array, i);
+    if (out_largest_file_id && out_largest_file_id_len > 0) {
+        out_largest_file_id[0] = '\0';
+        cJSON *largest = cJSON_GetArrayItem(photo_array, order[0]);
+        cJSON *largest_id = largest ? cJSON_GetObjectItem(largest, "file_id") : NULL;
+        if (largest_id && cJSON_IsString(largest_id)) {
+            strncpy(out_largest_file_id, largest_id->valuestring, out_largest_file_id_len - 1);
+            out_largest_file_id[out_largest_file_id_len - 1] = '\0';
+        }
+    }
+
+    for (int rank = 0; rank < n; rank++) {
+        int idx = order[rank];
+        cJSON *size_obj = cJSON_GetArrayItem(photo_array, idx);
         cJSON *file_id_item = cJSON_GetObjectItem(size_obj, "file_id");
         if (!file_id_item || !cJSON_IsString(file_id_item)) {
             continue;
@@ -572,14 +632,15 @@ static esp_err_t download_photo_with_fallback(cJSON *photo_array, char *out_path
         cJSON *fsize_item = cJSON_GetObjectItem(size_obj, "file_size");
         int approx_kb =
             (fsize_item && cJSON_IsNumber(fsize_item)) ? (int) (fsize_item->valuedouble / 1024) : -1;
-        ESP_LOGI(TAG, "Trying Telegram photo size %d/%d (~%d KB)", i + 1, n, approx_kb);
+        ESP_LOGI(TAG, "Trying Telegram photo size %d/%d (%lldpx area, ~%d KB)", rank + 1, n,
+                 area[idx], approx_kb);
 
         if (make_unique_telegram_path("jpg", out_path, out_path_len) != ESP_OK) {
             return ESP_FAIL;
         }
 
         if (telegram_download_file_id(file_id_item->valuestring, out_path) != ESP_OK) {
-            ESP_LOGW(TAG, "Size %d/%d failed to download, falling back to smaller", i + 1, n);
+            ESP_LOGW(TAG, "Size %d/%d failed to download, falling back to smaller", rank + 1, n);
             continue;
         }
 
@@ -587,7 +648,7 @@ static esp_err_t download_photo_with_fallback(cJSON *photo_array, char *out_path
             ESP_LOGW(TAG,
                      "Size %d/%d is a progressive JPEG (unsupported by decoder), falling back to "
                      "smaller",
-                     i + 1, n);
+                     rank + 1, n);
             unlink(out_path);
             continue;
         }
@@ -738,106 +799,6 @@ static esp_err_t process_and_display_telegram_image(const char *path, const char
     return show_err;
 }
 
-// Generates a small preview thumbnail sidecar next to an already-persisted
-// (processed, display-ready) Telegram image, named "<basename>.jpg" - the
-// same sidecar convention the Web UI upload path uses (a client-generated
-// real JPEG there; here it's PNG-encoded bytes under a ".jpg" name, since
-// the firmware has no JPEG encoder - browsers render by sniffing content,
-// not by trusting the extension, so this displays fine). Using ".jpg"
-// unconditionally (not swapping to match the source's own extension) is
-// deliberate: the source is always finalized to ".png" by
-// finalize_telegram_image() before this runs, and a same-named ".png"
-// thumbnail would silently overwrite the full-size image it's a thumbnail
-// of. Best-effort: logs and returns on failure, never treated as fatal by
-// the caller - a missing thumbnail just falls back to the icon+filename
-// placeholder in the gallery.
-static void generate_telegram_thumbnail(const char *image_path)
-{
-    image_format_t format = image_processor_detect_format(image_path);
-    if (format != IMAGE_FORMAT_JPG && format != IMAGE_FORMAT_PNG) {
-        return;
-    }
-
-    const char *source_path = image_path;
-    if (format == IMAGE_FORMAT_JPG || !image_processor_is_processed(image_path)) {
-        // Shouldn't normally happen anymore (finalize_telegram_image() below
-        // converts to a processed PNG first) - kept as a defensive fallback
-        // for whatever it didn't convert (e.g. processing failed upstream).
-        dither_algorithm_t algo = processing_settings_get_dithering_algorithm();
-        esp_err_t err = image_processor_process(image_path, TELEGRAM_THUMB_SCRATCH_PATH, algo);
-        if (err != ESP_OK) {
-            ESP_LOGW(TAG, "Thumbnail: failed to process %s: %s", image_path,
-                     esp_err_to_name(err));
-            return;
-        }
-        source_path = TELEGRAM_THUMB_SCRATCH_PATH;
-    }
-
-    char thumb_path[320];
-    strncpy(thumb_path, image_path, sizeof(thumb_path) - 1);
-    thumb_path[sizeof(thumb_path) - 1] = '\0';
-    char *ext = strrchr(thumb_path, '.');
-    if (!ext || (size_t) (ext - thumb_path) + 4 >= sizeof(thumb_path)) {
-        return;
-    }
-    strcpy(ext, ".jpg");
-
-    esp_err_t err = image_processor_make_thumbnail(source_path, TELEGRAM_THUMBNAIL_MAX_DIMENSION,
-                                                   thumb_path);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Thumbnail: failed to generate for %s: %s", image_path,
-                 esp_err_to_name(err));
-    }
-}
-
-// Converts a downloaded Telegram image to a permanent, properly persisted
-// PNG in place (same directory/basename, extension -> .png) if it isn't
-// already one, then generates its thumbnail sidecar. Raw downloaded JPEGs
-// (the normal case - Telegram "photo" sends are always JPEG) otherwise stay
-// invisible to the rest of the system: the Web UI gallery
-// (album_images_handler) and fallback album rotation (rotate_sequential /
-// rotate_random in display_manager.c) both only recognize .bmp/.png/.epdgz,
-// never a bare .jpg. This is what a manual Web UI upload already gets for
-// free (client-side conversion before upload); Telegram downloads need it
-// done here instead, since there's no client-side step in that path.
-//
-// Must be called AFTER any orientation-mismatch/pairing decision that needs
-// the image's original aspect ratio: a "processed" PNG is always padded to
-// the panel's fixed display resolution, which no longer reflects the source
-// photo's own portrait/landscape shape.
-//
-// `path` is updated in place if the file was converted. Best-effort: on
-// processing failure, leaves `path` untouched (falls back to the original
-// raw file, same as before this existed) and only logs a warning.
-static void finalize_telegram_image(char *path, size_t path_len)
-{
-    image_format_t format = image_processor_detect_format(path);
-    bool needs_conversion =
-        (format == IMAGE_FORMAT_JPG || (format == IMAGE_FORMAT_PNG && !image_processor_is_processed(path)));
-
-    if (needs_conversion) {
-        char png_path[320];
-        strncpy(png_path, path, sizeof(png_path) - 1);
-        png_path[sizeof(png_path) - 1] = '\0';
-        char *ext = strrchr(png_path, '.');
-        if (ext && (size_t) (ext - png_path) + 4 < sizeof(png_path)) {
-            strcpy(ext, ".png");
-            dither_algorithm_t algo = processing_settings_get_dithering_algorithm();
-            esp_err_t err = image_processor_process(path, png_path, algo);
-            if (err == ESP_OK) {
-                unlink(path);
-                strncpy(path, png_path, path_len - 1);
-                path[path_len - 1] = '\0';
-            } else {
-                ESP_LOGW(TAG, "Failed to persist %s as PNG, keeping original: %s", path,
-                         esp_err_to_name(err));
-            }
-        }
-    }
-
-    generate_telegram_thumbnail(path);
-}
-
 // Reads an entire file into a heap_caps (SPIRAM) buffer.
 static esp_err_t read_whole_file(const char *path, uint8_t **out_data, long *out_size)
 {
@@ -866,6 +827,199 @@ static esp_err_t read_whole_file(const char *path, uint8_t **out_data, long *out
     *out_data = buf;
     *out_size = size;
     return ESP_OK;
+}
+
+// Generates a small preview thumbnail sidecar named "<basename-of-final_path>.jpg"
+// - the same sidecar convention the Web UI upload path uses (a client-generated
+// real JPEG there; here it's PNG-encoded bytes under a ".jpg" name, since the
+// firmware has no JPEG encoder - browsers render by sniffing content, not by
+// trusting the extension, so this displays fine). Decodes `image_path`
+// directly with NO e-paper processing (no CDR, no dithering, no palette
+// quantization) - the thumbnail must be generated from the original photo,
+// not the low-color-depth, palette-quantized display PNG, otherwise the Web
+// UI/Telegram preview looks posterized instead of like a normal photo.
+//
+// `final_path` is the eventual display file's path (may be `image_path`
+// itself when no conversion is needed) - the thumbnail is always named after
+// IT, never after `image_path` directly, so that when a raw ".jpg" download
+// is about to be recycled into its own display PNG's thumbnail sidecar (the
+// common case - see finalize_telegram_image()), the two intentionally end up
+// sharing a filename instead of colliding with some other, unintended file.
+//
+// Best-effort: logs and returns an error on failure, never treated as fatal
+// by the caller - a missing thumbnail just falls back to the icon+filename
+// placeholder in the gallery.
+static esp_err_t generate_original_thumbnail(const char *image_path, image_format_t format,
+                                              const char *final_path)
+{
+    if (format != IMAGE_FORMAT_JPG && format != IMAGE_FORMAT_PNG) {
+        return ESP_ERR_NOT_SUPPORTED;  // BMP/EPDGZ document - no true-color source to thumbnail
+    }
+
+    char thumb_path[320];
+    strncpy(thumb_path, final_path, sizeof(thumb_path) - 1);
+    thumb_path[sizeof(thumb_path) - 1] = '\0';
+    char *ext = strrchr(thumb_path, '.');
+    if (!ext || (size_t) (ext - thumb_path) + 4 >= sizeof(thumb_path)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    strcpy(ext, ".jpg");
+
+    esp_err_t err = image_processor_make_thumbnail_from_original(
+        image_path, format, TELEGRAM_THUMBNAIL_MAX_DIMENSION, thumb_path);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Thumbnail: failed to generate for %s: %s", image_path,
+                 esp_err_to_name(err));
+    }
+    return err;
+}
+
+// Same idea, but for a source that has already been through e-paper
+// processing and has no separate "original" (a freshly composed
+// orientation-pair) - thumbnails whatever's actually on disk instead.
+static void generate_processed_thumbnail(const char *image_path)
+{
+    char thumb_path[320];
+    strncpy(thumb_path, image_path, sizeof(thumb_path) - 1);
+    thumb_path[sizeof(thumb_path) - 1] = '\0';
+    char *ext = strrchr(thumb_path, '.');
+    if (!ext || (size_t) (ext - thumb_path) + 4 >= sizeof(thumb_path)) {
+        return;
+    }
+    strcpy(ext, ".jpg");
+
+    esp_err_t err = image_processor_make_thumbnail(image_path, TELEGRAM_THUMBNAIL_MAX_DIMENSION,
+                                                   thumb_path);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Thumbnail: failed to generate for %s: %s", image_path,
+                 esp_err_to_name(err));
+    }
+}
+
+// Preserves the original (pre-processing) image into TELEGRAM_ORIGINALS_DIRECTORY
+// - a plain subfolder, never an active album (album_manager only lists
+// directories directly under IMAGE_DIRECTORY, and rotation/gallery only list
+// files, never recurse into subdirectories - both silently ignore it). Only
+// called when config_manager_get_telegram_keep_originals_enabled() is on.
+//
+// `archival_file_id`, when non-empty, is a Telegram file_id for a "photo"
+// message's LARGEST size (see download_photo_with_fallback()) - fetched
+// fresh here rather than copying the locally saved `path`, because `path`
+// may only be a smaller fallback size (the true largest can be an
+// undecodable progressive JPEG that download_photo_with_fallback() itself
+// had to skip for display purposes). No decode is needed to archive raw
+// bytes, so the progressive/unsupported size is fine here. Pass an empty
+// string/NULL for "document" uploads (single size - already the original,
+// `path` itself is exactly right).
+//
+// Best-effort: logs and returns on failure, never blocks finalization.
+static void preserve_telegram_original(const char *path, const char *archival_file_id)
+{
+    mkdir(TELEGRAM_ORIGINALS_DIRECTORY, 0775);  // no-op if it already exists
+
+    const char *fname = strrchr(path, '/');
+    fname = fname ? fname + 1 : path;
+    char dest[320];
+    snprintf(dest, sizeof(dest), "%s/%s", TELEGRAM_ORIGINALS_DIRECTORY, fname);
+
+    if (archival_file_id && archival_file_id[0] != '\0') {
+        if (telegram_download_file_id(archival_file_id, dest) == ESP_OK) {
+            return;
+        }
+        ESP_LOGW(TAG, "Failed to fetch largest photo size for archival, falling back to local copy");
+    }
+
+    uint8_t *data = NULL;
+    long size = 0;
+    if (read_whole_file(path, &data, &size) != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to read %s to preserve original", path);
+        return;
+    }
+    FILE *out = fopen(dest, "wb");
+    if (!out) {
+        ESP_LOGW(TAG, "Failed to open %s to preserve original", dest);
+        heap_caps_free(data);
+        return;
+    }
+    size_t written = fwrite(data, 1, (size_t) size, out);
+    fclose(out);
+    heap_caps_free(data);
+    if (written != (size_t) size) {
+        ESP_LOGW(TAG, "Short write preserving original to %s", dest);
+        unlink(dest);
+    }
+}
+
+// Converts a downloaded Telegram image to a permanent, properly persisted
+// PNG in place (same directory/basename, extension -> .png) if it isn't
+// already one. Raw downloaded JPEGs (the normal case - Telegram "photo"
+// sends are always JPEG) otherwise stay invisible to the rest of the
+// system: the Web UI gallery (album_images_handler) and fallback album
+// rotation (rotate_sequential / rotate_random in display_manager.c) both
+// only recognize .bmp/.png/.epdgz, never a bare .jpg. This is what a manual
+// Web UI upload already gets for free (client-side conversion before
+// upload); Telegram downloads need it done here instead, since there's no
+// client-side step in that path.
+//
+// Must be called AFTER any orientation-mismatch/pairing decision that needs
+// the image's original aspect ratio: a "processed" PNG is always padded to
+// the panel's fixed display resolution, which no longer reflects the source
+// photo's own portrait/landscape shape.
+//
+// `path` is updated in place if the file was converted. Best-effort: on
+// processing failure, leaves `path` untouched (falls back to the original
+// raw file, same as before this existed) and only logs a warning.
+//
+// `archival_file_id`: see preserve_telegram_original() - the Telegram
+// file_id of a "photo" message's largest size, or NULL/empty for a document
+// upload (single size, `path` is already the original).
+static void finalize_telegram_image(char *path, size_t path_len, const char *archival_file_id)
+{
+    image_format_t format = image_processor_detect_format(path);
+    bool needs_conversion =
+        (format == IMAGE_FORMAT_JPG || (format == IMAGE_FORMAT_PNG && !image_processor_is_processed(path)));
+
+    if (!needs_conversion) {
+        // Already a processed, display-ready PNG - thumbnail it as-is. Its
+        // ".jpg" sidecar name can never collide with the ".png" source.
+        generate_original_thumbnail(path, format, path);
+        return;
+    }
+
+    if (config_manager_get_telegram_keep_originals_enabled()) {
+        preserve_telegram_original(path, archival_file_id);
+    }
+
+    char png_path[320];
+    strncpy(png_path, path, sizeof(png_path) - 1);
+    png_path[sizeof(png_path) - 1] = '\0';
+    char *ext = strrchr(png_path, '.');
+    if (!ext || (size_t) (ext - png_path) + 4 >= sizeof(png_path)) {
+        return;
+    }
+    strcpy(ext, ".png");
+
+    dither_algorithm_t algo = processing_settings_get_dithering_algorithm();
+    esp_err_t err = image_processor_process(path, png_path, algo);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to persist %s as PNG, keeping original: %s", path,
+                 esp_err_to_name(err));
+        return;
+    }
+
+    // The raw download (still holding valid, undamaged bytes at this point -
+    // both the optional preserved original and the display PNG above were
+    // already produced from it) is recycled in place into the display PNG's
+    // ".jpg" thumbnail sidecar: generate_original_thumbnail() derives that
+    // exact filename from png_path, which - since `path` and png_path share
+    // a basename and only differ by extension - is exactly `path` itself. On
+    // thumbnail failure there's nothing worth keeping at `path` any more, so
+    // it's deleted instead (matching the old unconditional cleanup).
+    if (generate_original_thumbnail(path, format, png_path) != ESP_OK) {
+        unlink(path);
+    }
+    strncpy(path, png_path, path_len - 1);
+    path[path_len - 1] = '\0';
 }
 
 // Uploads a local file as a brand-new Telegram photo (multipart/form-data
@@ -1368,12 +1522,14 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
         cJSON *document = cJSON_GetObjectItem(message, "document");
         char downloaded_path[320];
         char thumb_file_id[TELEGRAM_FILE_ID_MAX_LEN];
+        char largest_file_id[TELEGRAM_FILE_ID_MAX_LEN] = {0};
         bool got_image = false;
 
         if (photo && cJSON_IsArray(photo) && cJSON_GetArraySize(photo) > 0) {
             got_image = (download_photo_with_fallback(photo, downloaded_path,
                                                        sizeof(downloaded_path), thumb_file_id,
-                                                       sizeof(thumb_file_id)) == ESP_OK);
+                                                       sizeof(thumb_file_id), largest_file_id,
+                                                       sizeof(largest_file_id)) == ESP_OK);
             if (!got_image) {
                 image_attempt_failed = true;
             }
@@ -1414,7 +1570,7 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
             // this image is visible to the Web UI gallery and fallback
             // album rotation, same as any other album image - see
             // finalize_telegram_image() for why a raw download isn't.
-            finalize_telegram_image(downloaded_path, sizeof(downloaded_path));
+            finalize_telegram_image(downloaded_path, sizeof(downloaded_path), largest_file_id);
 
             if (saved_image_count < TELEGRAM_MAX_TRACKED_IMAGES) {
                 telegram_saved_image_t *entry = &saved_images[saved_image_count++];
@@ -1473,7 +1629,7 @@ esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result)
                         paired = true;
 
                         if (pr->ok) {
-                            generate_telegram_thumbnail(pr->composed_path);
+                            generate_processed_thumbnail(pr->composed_path);
                             ESP_LOGI(TAG, "Composed and saved paired image: %s", pr->composed_path);
                             strncpy(display_path, pr->composed_path, sizeof(display_path) - 1);
                             display_path[sizeof(display_path) - 1] = '\0';
@@ -1695,7 +1851,8 @@ static void format_toggles(char *out, size_t out_len)
              "[%c] Error overlay\n"
              "[%c] WiFi performance\n"
              "[%c] Rotation pairing (random mode only)\n"
-             "[%c] Rotation notify (thumbnail on fallback display)",
+             "[%c] Rotation notify (thumbnail on fallback display)\n"
+             "[%c] Keep originals (pre-processing copies)",
              config_manager_get_telegram_pairing_enabled() ? 'x' : ' ',
              config_manager_get_deep_sleep_enabled() ? 'x' : ' ',
              config_manager_get_auto_rotate() ? 'x' : ' ',
@@ -1703,7 +1860,8 @@ static void format_toggles(char *out, size_t out_len)
              config_manager_get_error_overlay_enabled() ? 'x' : ' ',
              config_manager_get_wifi_performance_mode_enabled() ? 'x' : ' ',
              config_manager_get_rotation_pairing_enabled() ? 'x' : ' ',
-             config_manager_get_telegram_rotation_notify_enabled() ? 'x' : ' ');
+             config_manager_get_telegram_rotation_notify_enabled() ? 'x' : ' ',
+             config_manager_get_telegram_keep_originals_enabled() ? 'x' : ' ');
 }
 
 static void format_rotation_schedule(char *out, size_t out_len)
@@ -1953,6 +2111,18 @@ static void execute_command(const char *raw_text)
         } else {
             telegram_bot_send_message("[i] Usage: /rotation_notify on|off");
         }
+    } else if (strcmp(cmd, "/keep_originals") == 0) {
+        if (args && strcasecmp(args, "on") == 0) {
+            config_manager_set_telegram_keep_originals_enabled(true);
+            telegram_bot_send_message(
+                "[x] Keep originals enabled\n"
+                "(each Telegram photo is also saved, as received, under Telegram/Originals).");
+        } else if (args && strcasecmp(args, "off") == 0) {
+            config_manager_set_telegram_keep_originals_enabled(false);
+            telegram_bot_send_message("[ ] Keep originals disabled.");
+        } else {
+            telegram_bot_send_message("[i] Usage: /keep_originals on|off");
+        }
     } else if (strcmp(cmd, "/list_albums") == 0) {
         char **albums = NULL;
         int count = 0;
@@ -2047,6 +2217,8 @@ static void execute_command(const char *raw_text)
             "  during auto-rotation (random mode only, no effect in sequential mode)\n"
             "/rotation_notify on|off - Send a thumbnail when a wake displays an\n"
             "  image that didn't come from Telegram (i.e. fallback rotation)\n"
+            "/keep_originals on|off - Save each Telegram photo as received,\n"
+            "  before e-paper processing, under Telegram/Originals\n"
             "\n"
             "Emergency:\n"
             "/telegram_reset - Clear the queue immediately\n"

--- a/main/telegram_bot.h
+++ b/main/telegram_bot.h
@@ -61,4 +61,12 @@ void telegram_bot_run_pending_commands(void);
 // success. No-op (ESP_ERR_INVALID_STATE) if Telegram isn't configured.
 esp_err_t telegram_bot_send_message(const char *text);
 
+// Sends a thumbnail (or, failing that, the full image) of an image that was
+// just displayed via fallback album rotation - i.e. NOT from a Telegram
+// push - so the chat still sees what the frame is showing even when nothing
+// new was sent. Call only when
+// config_manager_get_telegram_rotation_notify_enabled() is true. No-op
+// (ESP_ERR_INVALID_STATE) if Telegram isn't configured.
+esp_err_t telegram_bot_notify_fallback_image(const char *image_path);
+
 #endif

--- a/main/telegram_bot.h
+++ b/main/telegram_bot.h
@@ -1,0 +1,57 @@
+#ifndef TELEGRAM_BOT_H
+#define TELEGRAM_BOT_H
+
+#include "esp_err.h"
+
+// Result of a single telegram_bot_poll() call.
+typedef enum {
+    // Polled successfully. Any new images were downloaded (progressive
+    // fallback applied) and the newest one displayed; any "/" commands found
+    // were queued for telegram_bot_run_pending_commands().
+    TELEGRAM_POLL_OK = 0,
+
+    // The emergency "/telegram_reset" command was found in this batch. All
+    // other updates in the batch were skipped, update_id was advanced past
+    // the whole batch, and a confirmation was already sent. The caller MUST
+    // skip straight to deep sleep - do not display images or run commands.
+    TELEGRAM_POLL_RESET,
+
+    // Bot token or chat ID not configured - nothing was done.
+    TELEGRAM_POLL_NOT_CONFIGURED,
+
+    // Network/HTTP/JSON error talking to the Telegram API.
+    TELEGRAM_POLL_ERROR,
+} telegram_poll_result_t;
+
+// Poll Telegram (getUpdates) for updates newer than the persisted
+// last_update_id, strictly filtered to the configured chat ID.
+//
+// Behavior (see telegram_poll_result_t for the RESET short-circuit):
+//  - Downloads every new photo/image-document in the batch into
+//    TELEGRAM_DOWNLOAD_DIRECTORY as "img_<unix-timestamp>.<ext>". For
+//    Telegram "photo" messages (which carry several re-encoded resolutions,
+//    largest last) the largest is tried first; on failure (too large,
+//    network error, or an unsupported *progressive* JPEG - Telegram
+//    re-encodes compressed photos as progressive JPEG, which this
+//    firmware's JPEG decoder cannot decode) the next smaller size is tried,
+//    down to the smallest, until one succeeds or all fail.
+//  - The newest successfully downloaded image is run through the existing
+//    processing pipeline and shown on the display; older images stay on
+//    storage for later rotation cycles.
+//  - Any message text starting with "/" (other than the reset command) is
+//    queued as a pending command.
+//  - Persists the highest update_id seen (+1 offset) to NVS so updates are
+//    never re-processed.
+esp_err_t telegram_bot_poll(telegram_poll_result_t *out_result);
+
+// Runs every command queued by the last telegram_bot_poll() call, sending a
+// sendMessage reply for each (e.g. /status, /restart, /clear). Call after
+// image display, before deep sleep. No-op if the queue is empty. Note:
+// /restart calls esp_restart() immediately and does not return.
+void telegram_bot_run_pending_commands(void);
+
+// Sends a free-form text message to the configured chat. Returns ESP_OK on
+// success. No-op (ESP_ERR_INVALID_STATE) if Telegram isn't configured.
+esp_err_t telegram_bot_send_message(const char *text);
+
+#endif

--- a/main/telegram_bot.h
+++ b/main/telegram_bot.h
@@ -5,10 +5,17 @@
 
 // Result of a single telegram_bot_poll() call.
 typedef enum {
-    // Polled successfully. Any new images were downloaded (progressive
-    // fallback applied) and the newest one displayed; any "/" commands found
-    // were queued for telegram_bot_run_pending_commands().
+    // Polled successfully, and a new image was displayed. Any "/" commands
+    // found were queued for telegram_bot_run_pending_commands().
     TELEGRAM_POLL_OK = 0,
+
+    // Polled successfully, but nothing was displayed this cycle - either
+    // there were no new messages, or none of the messages in this batch
+    // resulted in a displayable image (e.g. only commands, or an image is
+    // still waiting for its orientation-pairing partner). The caller should
+    // fall back to normal album rotation so the frame still changes image
+    // on this wake, same as the non-Telegram rotation modes.
+    TELEGRAM_POLL_OK_NO_IMAGE,
 
     // The emergency "/telegram_reset" command was found in this batch. All
     // other updates in the batch were skipped, update_id was advanced past

--- a/main/utils.c
+++ b/main/utils.c
@@ -27,6 +27,7 @@
 #include "power_manager.h"
 #include "processing_settings.h"
 #include "storage.h"
+#include "telegram_bot.h"
 #include "wifi_manager.h"
 
 static const char *TAG = "utils";
@@ -367,6 +368,8 @@ esp_err_t apply_config_from_json(cJSON *root)
         rotation_mode_t mode = ROTATION_MODE_STORAGE;
         if (strcmp(mode_str, "url") == 0)
             mode = ROTATION_MODE_URL;
+        else if (strcmp(mode_str, "telegram") == 0)
+            mode = ROTATION_MODE_TELEGRAM;
         // Backwards compatibility: accept "sdcard" as alias for "storage"
         if (strcmp(mode_str, "sdcard") == 0)
             mode = ROTATION_MODE_STORAGE;
@@ -437,6 +440,52 @@ esp_err_t apply_config_from_json(cJSON *root)
         config_manager_set_ha_url(cJSON_GetStringValue(item));
     }
 
+    item = cJSON_GetObjectItem(root, "ha_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_ha_enabled(cJSON_IsTrue(item));
+    }
+
+    // Telegram Bot
+    item = cJSON_GetObjectItem(root, "telegram_bot_token");
+    if (item && cJSON_IsString(item)) {
+        config_manager_set_telegram_bot_token(cJSON_GetStringValue(item));
+    }
+
+    item = cJSON_GetObjectItem(root, "telegram_chat_id");
+    if (item && cJSON_IsString(item)) {
+        const char *chat_id = cJSON_GetStringValue(item);
+        // Must be empty (clearing) or a plain integer (optionally negative -
+        // Telegram uses negative IDs for groups/supergroups).
+        bool valid = true;
+        for (size_t i = 0; chat_id[i] != '\0' && valid; i++) {
+            if (chat_id[i] == '-' && i == 0) {
+                continue;
+            }
+            if (chat_id[i] < '0' || chat_id[i] > '9') {
+                valid = false;
+            }
+        }
+        if (!valid) {
+            utils_set_config_error("Telegram chat ID must be a numeric ID");
+            return ESP_FAIL;
+        }
+        config_manager_set_telegram_chat_id(chat_id);
+    }
+
+    item = cJSON_GetObjectItem(root, "telegram_pairing_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_telegram_pairing_enabled(cJSON_IsTrue(item));
+        if (!cJSON_IsTrue(item)) {
+            // Clears the tracking queue only - files stay on storage.
+            config_manager_clear_telegram_pending_images();
+        }
+    }
+
+    item = cJSON_GetObjectItem(root, "telegram_wake_notify_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_telegram_wake_notify_enabled(cJSON_IsTrue(item));
+    }
+
     // AI API Keys
     item = cJSON_GetObjectItem(root, "openai_api_key");
     if (item && cJSON_IsString(item)) {
@@ -458,6 +507,24 @@ esp_err_t apply_config_from_json(cJSON *root)
     item = cJSON_GetObjectItem(root, "debug_log_enabled");
     if (item && cJSON_IsBool(item)) {
         debug_log_set_enabled(cJSON_IsTrue(item));
+    }
+
+    // OTA
+    item = cJSON_GetObjectItem(root, "ota_check_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_ota_check_enabled(cJSON_IsTrue(item));
+    }
+
+    // Error overlay
+    item = cJSON_GetObjectItem(root, "error_overlay_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_error_overlay_enabled(cJSON_IsTrue(item));
+    }
+
+    // WiFi performance mode
+    item = cJSON_GetObjectItem(root, "wifi_performance_mode_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_wifi_performance_mode_enabled(cJSON_IsTrue(item));
     }
 
     return ESP_OK;
@@ -1146,12 +1213,103 @@ esp_err_t fetch_and_save_image_from_url(const char *url, char *saved_image_path,
     return ESP_OK;
 }
 
+// Overlays a short message on the currently displayed image WITHOUT modifying
+// the original saved file: copies it to the scratch PNG path first, draws the
+// caption there, and displays the copy.
+static void display_error_overlay(const char *message)
+{
+    const char *current_image = display_manager_get_current_image();
+    if (!current_image || current_image[0] == '\0') {
+        ESP_LOGW(TAG, "No current image to overlay error onto, skipping");
+        return;
+    }
+
+    image_format_t format = image_processor_detect_format(current_image);
+    if (format != IMAGE_FORMAT_PNG || !image_processor_is_processed(current_image)) {
+        ESP_LOGW(TAG, "Current image %s is not an overlay-ready processed PNG, skipping",
+                 current_image);
+        return;
+    }
+
+    FILE *src = fopen(current_image, "rb");
+    if (!src) {
+        ESP_LOGE(TAG, "Failed to open %s for error overlay", current_image);
+        return;
+    }
+    FILE *dst = fopen(CURRENT_PNG_PATH, "wb");
+    if (!dst) {
+        fclose(src);
+        ESP_LOGE(TAG, "Failed to open %s for error overlay", CURRENT_PNG_PATH);
+        return;
+    }
+    char buf[512];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), src)) > 0) {
+        fwrite(buf, 1, n, dst);
+    }
+    fclose(src);
+    fclose(dst);
+
+    image_processor_add_caption_to_file(CURRENT_PNG_PATH, message);
+    display_manager_show_image(CURRENT_PNG_PATH);
+    ESP_LOGW(TAG, "Displayed error overlay: %s", message);
+}
+
+void utils_handle_wifi_connect_result(bool connected)
+{
+    if (connected) {
+        if (config_manager_get_wifi_fail_count() != 0) {
+            config_manager_set_wifi_fail_count(0);
+        }
+        return;
+    }
+
+    int count = config_manager_get_wifi_fail_count() + 1;
+    config_manager_set_wifi_fail_count(count);
+    ESP_LOGW(TAG, "WiFi connect failed (%d consecutive)", count);
+
+    if (!config_manager_get_error_overlay_enabled() || count < WIFI_FAIL_OVERLAY_THRESHOLD) {
+        return;
+    }
+
+    char caption[96];
+    snprintf(caption, sizeof(caption), "Fehler: Keine WLAN-Verbindung (%dx in Folge)", count);
+    display_error_overlay(caption);
+}
+
 esp_err_t trigger_image_rotation(void)
 {
     rotation_mode_t rotation_mode = config_manager_get_rotation_mode();
     esp_err_t result = ESP_OK;
 
-    if (rotation_mode == ROTATION_MODE_URL) {
+    if (rotation_mode == ROTATION_MODE_TELEGRAM) {
+        // Telegram mode - poll getUpdates, download+display the newest image
+        // (with progressive-size fallback), queue any "/" commands.
+        telegram_poll_result_t poll_result = TELEGRAM_POLL_ERROR;
+        esp_err_t poll_err = telegram_bot_poll(&poll_result);
+
+        if (poll_result == TELEGRAM_POLL_RESET) {
+            // Emergency "/telegram_reset": the queue was already cleared and
+            // acknowledged inside telegram_bot_poll() - skip HA notify, the
+            // post-rotate HTTP window, everything, and sleep right now.
+            ESP_LOGW(TAG, "Telegram emergency reset - entering deep sleep immediately");
+            power_manager_enter_sleep();
+            // Not reached.
+        }
+
+        if (poll_err == ESP_OK) {
+            utils_set_last_fetch_error(NULL);
+            result = ESP_OK;
+        } else {
+            const char *reason = (poll_result == TELEGRAM_POLL_NOT_CONFIGURED)
+                                     ? "Telegram bot not configured"
+                                     : "Telegram poll failed";
+            ESP_LOGW(TAG, "%s, falling back to local rotation", reason);
+            utils_set_last_fetch_error(reason);
+            display_manager_rotate_from_storage();
+            result = ESP_FAIL;
+        }
+    } else if (rotation_mode == ROTATION_MODE_URL) {
         // URL mode - fetch image from URL
         const char *image_url = config_manager_get_image_url();
         ESP_LOGI(TAG, "URL rotation mode - downloading from: %s", image_url);

--- a/main/utils.c
+++ b/main/utils.c
@@ -527,6 +527,12 @@ esp_err_t apply_config_from_json(cJSON *root)
         config_manager_set_wifi_performance_mode_enabled(cJSON_IsTrue(item));
     }
 
+    // Auto-rotate orientation pairing (random mode only)
+    item = cJSON_GetObjectItem(root, "rotation_pairing_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_rotation_pairing_enabled(cJSON_IsTrue(item));
+    }
+
     return ESP_OK;
 }
 
@@ -1213,34 +1219,67 @@ esp_err_t fetch_and_save_image_from_url(const char *url, char *saved_image_path,
     return ESP_OK;
 }
 
+// Generates a blank white canvas at the panel's native resolution and
+// overlays the message on it - used whenever there's no existing displayed
+// image to overlay onto (fresh boot, after /clear, or a non-overlay-ready
+// current image). White is a valid palette entry on every supported panel,
+// so the buffer is already "processed" as far as image_processor_draw_caption
+// is concerned.
+static esp_err_t display_error_overlay_blank(const char *message)
+{
+    int width = BOARD_HAL_DISPLAY_WIDTH;
+    int height = BOARD_HAL_DISPLAY_HEIGHT;
+    size_t buf_size = (size_t) width * (size_t) height * 3;
+
+    uint8_t *rgb_buffer = heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
+    if (!rgb_buffer) {
+        ESP_LOGE(TAG, "Failed to allocate blank canvas for error overlay");
+        return ESP_ERR_NO_MEM;
+    }
+    memset(rgb_buffer, 0xFF, buf_size);
+
+    image_processor_draw_caption(rgb_buffer, width, height, message);
+    esp_err_t err = image_processor_write_rgb_to_png(rgb_buffer, width, height, CURRENT_PNG_PATH);
+    heap_caps_free(rgb_buffer);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to write blank error-overlay canvas: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    display_manager_show_image(CURRENT_PNG_PATH);
+    ESP_LOGW(TAG, "Displayed error overlay on a blank canvas: %s", message);
+    return ESP_OK;
+}
+
 // Overlays a short message on the currently displayed image WITHOUT modifying
 // the original saved file: copies it to the scratch PNG path first, draws the
-// caption there, and displays the copy.
-static void display_error_overlay(const char *message)
+// caption there, and displays the copy. Falls back to a blank canvas (see
+// above) if there's nothing suitable to overlay onto.
+static esp_err_t display_error_overlay(const char *message)
 {
     const char *current_image = display_manager_get_current_image();
     if (!current_image || current_image[0] == '\0') {
-        ESP_LOGW(TAG, "No current image to overlay error onto, skipping");
-        return;
+        ESP_LOGI(TAG, "No current image to overlay error onto, using a blank canvas");
+        return display_error_overlay_blank(message);
     }
 
     image_format_t format = image_processor_detect_format(current_image);
     if (format != IMAGE_FORMAT_PNG || !image_processor_is_processed(current_image)) {
-        ESP_LOGW(TAG, "Current image %s is not an overlay-ready processed PNG, skipping",
+        ESP_LOGI(TAG, "Current image %s is not an overlay-ready processed PNG, using a blank canvas",
                  current_image);
-        return;
+        return display_error_overlay_blank(message);
     }
 
     FILE *src = fopen(current_image, "rb");
     if (!src) {
         ESP_LOGE(TAG, "Failed to open %s for error overlay", current_image);
-        return;
+        return ESP_FAIL;
     }
     FILE *dst = fopen(CURRENT_PNG_PATH, "wb");
     if (!dst) {
         fclose(src);
         ESP_LOGE(TAG, "Failed to open %s for error overlay", CURRENT_PNG_PATH);
-        return;
+        return ESP_FAIL;
     }
     char buf[512];
     size_t n;
@@ -1253,6 +1292,7 @@ static void display_error_overlay(const char *message)
     image_processor_add_caption_to_file(CURRENT_PNG_PATH, message);
     display_manager_show_image(CURRENT_PNG_PATH);
     ESP_LOGW(TAG, "Displayed error overlay: %s", message);
+    return ESP_OK;
 }
 
 void utils_handle_wifi_connect_result(bool connected)
@@ -1273,8 +1313,16 @@ void utils_handle_wifi_connect_result(bool connected)
     }
 
     char caption[96];
-    snprintf(caption, sizeof(caption), "Fehler: Keine WLAN-Verbindung (%dx in Folge)", count);
+    snprintf(caption, sizeof(caption), "Error: No WiFi connection (%dx in a row)", count);
     display_error_overlay(caption);
+}
+
+esp_err_t utils_test_error_overlay(void)
+{
+    // Manual preview from the Web UI - always overlays the example message
+    // regardless of the error-overlay setting or the WiFi-fail counter, so
+    // it can be used to see what the feature looks like before enabling it.
+    return display_error_overlay("Error: No WiFi connection (3x in a row) - TEST");
 }
 
 esp_err_t trigger_image_rotation(void)
@@ -1299,6 +1347,15 @@ esp_err_t trigger_image_rotation(void)
 
         if (poll_err == ESP_OK) {
             utils_set_last_fetch_error(NULL);
+            if (poll_result == TELEGRAM_POLL_OK_NO_IMAGE) {
+                // No new Telegram image this cycle - still change the
+                // display, same as the non-Telegram rotation modes, by
+                // falling back to the active album(s) (this also covers the
+                // Telegram download folder, which shows up as a regular
+                // album - see telegram_bot_poll()).
+                ESP_LOGI(TAG, "No new Telegram image, falling back to local rotation");
+                display_manager_rotate_from_storage();
+            }
             result = ESP_OK;
         } else {
             const char *reason = (poll_result == TELEGRAM_POLL_NOT_CONFIGURED)

--- a/main/utils.c
+++ b/main/utils.c
@@ -552,6 +552,12 @@ esp_err_t apply_config_from_json(cJSON *root)
         config_manager_set_telegram_rotation_notify_enabled(cJSON_IsTrue(item));
     }
 
+    // Keep a copy of each Telegram photo as received, before e-paper processing
+    item = cJSON_GetObjectItem(root, "telegram_keep_originals_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_telegram_keep_originals_enabled(cJSON_IsTrue(item));
+    }
+
     return ESP_OK;
 }
 

--- a/main/utils.c
+++ b/main/utils.c
@@ -533,6 +533,12 @@ esp_err_t apply_config_from_json(cJSON *root)
         config_manager_set_rotation_pairing_enabled(cJSON_IsTrue(item));
     }
 
+    // Telegram notification on fallback-rotation display changes
+    item = cJSON_GetObjectItem(root, "telegram_rotation_notify_enabled");
+    if (item && cJSON_IsBool(item)) {
+        config_manager_set_telegram_rotation_notify_enabled(cJSON_IsTrue(item));
+    }
+
     return ESP_OK;
 }
 
@@ -1354,7 +1360,21 @@ esp_err_t trigger_image_rotation(void)
                 // Telegram download folder, which shows up as a regular
                 // album - see telegram_bot_poll()).
                 ESP_LOGI(TAG, "No new Telegram image, falling back to local rotation");
+
+                char prev_image[64];
+                const char *before = display_manager_get_current_image();
+                strncpy(prev_image, before ? before : "", sizeof(prev_image) - 1);
+                prev_image[sizeof(prev_image) - 1] = '\0';
+
                 display_manager_rotate_from_storage();
+
+                // Only notify if the display actually changed - rotation is
+                // a no-op when there are no enabled albums / no images.
+                const char *after = display_manager_get_current_image();
+                if (config_manager_get_telegram_rotation_notify_enabled() && after &&
+                    after[0] != '\0' && strcmp(after, prev_image) != 0) {
+                    telegram_bot_notify_fallback_image(after);
+                }
             }
             result = ESP_OK;
         } else {

--- a/main/utils.h
+++ b/main/utils.h
@@ -43,6 +43,13 @@ const char *utils_consume_config_error(void);
 esp_err_t fetch_and_save_image_from_url(const char *url, char *saved_image_path, size_t path_size,
                                         bool *not_modified);
 
+// Tracks consecutive scheduled-wake WiFi connection failures. Call with the
+// result of every connect attempt in the deep-sleep wake path; once the
+// count reaches WIFI_FAIL_OVERLAY_THRESHOLD, overlays a short error message
+// on the currently displayed image (if the error-overlay setting is
+// enabled) so a problem is visible on the frame itself, not just in logs.
+void utils_handle_wifi_connect_result(bool connected);
+
 // Trigger image rotation based on configured rotation mode
 // Handles both URL and SD card rotation modes
 // Returns ESP_OK on success, error code on failure

--- a/main/utils.h
+++ b/main/utils.h
@@ -50,6 +50,11 @@ esp_err_t fetch_and_save_image_from_url(const char *url, char *saved_image_path,
 // enabled) so a problem is visible on the frame itself, not just in logs.
 void utils_handle_wifi_connect_result(bool connected);
 
+// Manual preview: overlays an example error message on the currently
+// displayed image (or a blank canvas if nothing suitable is currently
+// displayed), regardless of the error-overlay setting.
+esp_err_t utils_test_error_overlay(void);
+
 // Trigger image rotation based on configured rotation mode
 // Handles both URL and SD card rotation modes
 // Returns ESP_OK on success, error code on failure

--- a/main/wifi_manager.c
+++ b/main/wifi_manager.c
@@ -2,6 +2,7 @@
 
 #include <string.h>
 
+#include "board_hal.h"
 #include "config.h"
 #include "config_manager.h"
 #include "esp_event.h"
@@ -221,6 +222,23 @@ esp_err_t wifi_manager_connect(const char *ssid, const char *password)
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
     ESP_ERROR_CHECK(esp_wifi_start());
+
+    // On battery, associating with an AP draws a brief high-current TX burst
+    // that a marginal battery/PMIC rail may not sustain without a voltage dip
+    // severe enough to glitch a concurrent SPI flash/PSRAM read (a real ESP32
+    // failure mode: it can trigger a CPU exception without ever tripping the
+    // brownout detector's own reset). Capping TX power measurably lowers that
+    // peak, at some cost to range - only applied off USB, where the extra
+    // headroom isn't needed. Best-effort: failure here shouldn't block
+    // connecting at default power.
+    if (!board_hal_is_usb_connected()) {
+        esp_err_t tx_err = esp_wifi_set_max_tx_power(WIFI_BATTERY_MAX_TX_POWER_QUARTER_DBM);
+        if (tx_err != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to cap TX power for battery operation: %s",
+                     esp_err_to_name(tx_err));
+        }
+    }
+
     ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_MIN_MODEM));  // Enable power save at boot/connect
 
     s_retry_num = 0;

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -32,8 +32,11 @@ CONFIG_FATFS_MAX_LFN=255
 # FreeRTOS
 CONFIG_FREERTOS_HZ=1000
 
-# Main task stack size - Increase for WiFi and HTTP client operations
-CONFIG_ESP_MAIN_TASK_STACK_SIZE=6144
+# Main task stack size - the deep-sleep wake path runs the whole Telegram
+# pipeline (HTTPS/TLS + JSON + image composition + file I/O) synchronously
+# on this task; 6144 was coredump-confirmed too small (vApplicationStackOverflowHook,
+# task 'main'). Doubled with margin rather than trimming individual buffers.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=12288
 
 # Component config
 CONFIG_LWIP_MAX_SOCKETS=16

--- a/webapp/src/components/AlbumGallery.vue
+++ b/webapp/src/components/AlbumGallery.vue
@@ -164,7 +164,7 @@ function onShowThumbnailsChange(val) {
           >
             <v-card variant="outlined" class="image-card">
               <v-img
-                v-if="showThumbnails"
+                v-if="showThumbnails && image.thumbnail"
                 :src="getThumbnailUrl(image)"
                 :alt="image.filename"
                 aspect-ratio="1"

--- a/webapp/src/components/AlbumGallery.vue
+++ b/webapp/src/components/AlbumGallery.vue
@@ -66,6 +66,15 @@ async function deleteImage() {
 function getThumbnailUrl(image) {
   return `/api/image?filepath=${encodeURIComponent(image.album + "/" + image.thumbnail)}`;
 }
+
+// Loading many thumbnails at once noticeably slows down the device's own
+// HTTP server, so thumbnail rendering in the grid defaults to off; the
+// preference is remembered per-browser (not synced to the device).
+const showThumbnails = ref(localStorage.getItem("photoframe_show_thumbnails") === "true");
+function onShowThumbnailsChange(val) {
+  showThumbnails.value = val;
+  localStorage.setItem("photoframe_show_thumbnails", val ? "true" : "false");
+}
 </script>
 
 <template>
@@ -128,6 +137,15 @@ function getThumbnailUrl(image) {
         <v-spacer />
         <v-progress-circular v-if="displayLoading" indeterminate size="24" class="mr-2" />
         <span v-if="displayLoading" class="text-body-2 text-grey"> Updating display... </span>
+        <v-switch
+          :model-value="showThumbnails"
+          label="Show thumbnails"
+          color="primary"
+          density="compact"
+          hide-details
+          class="flex-grow-0 ml-2"
+          @update:model-value="onShowThumbnailsChange"
+        />
       </div>
 
       <div v-if="appStore.loading.images" class="d-flex justify-center align-center py-12">
@@ -146,6 +164,7 @@ function getThumbnailUrl(image) {
           >
             <v-card variant="outlined" class="image-card">
               <v-img
+                v-if="showThumbnails"
                 :src="getThumbnailUrl(image)"
                 :alt="image.filename"
                 aspect-ratio="1"
@@ -159,6 +178,17 @@ function getThumbnailUrl(image) {
                   </div>
                 </template>
               </v-img>
+              <div
+                v-else
+                class="d-flex flex-column align-center justify-center cursor-pointer bg-grey-lighten-3 pa-2 thumbnail-placeholder"
+                style="aspect-ratio: 1"
+                @click="confirmDisplayImage(image)"
+              >
+                <v-icon icon="mdi-image-outline" size="32" color="grey" />
+                <span class="text-caption text-grey text-truncate" style="max-width: 100%">{{
+                  image.filename
+                }}</span>
+              </div>
               <div class="delete-hotspot">
                 <v-btn
                   icon="mdi-delete"

--- a/webapp/src/components/BatteryHistory.vue
+++ b/webapp/src/components/BatteryHistory.vue
@@ -1,0 +1,230 @@
+<script setup>
+import { ref, computed, onMounted } from "vue";
+
+const API_BASE = "";
+
+const loading = ref(true);
+const entries = ref([]); // [{ t: unixSeconds, p: 0-100, c: boolean }]
+const daysRemaining = ref(null);
+
+async function loadHistory() {
+  loading.value = true;
+  try {
+    const response = await fetch(`${API_BASE}/api/battery-history`);
+    if (!response.ok || response.headers.get("content-type")?.includes("text/html")) {
+      return;
+    }
+    const data = await response.json();
+    entries.value = data.entries || [];
+    daysRemaining.value = data.days_remaining ?? null;
+  } catch (_error) {
+    console.log("Battery history not available (standalone mode)");
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(loadHistory);
+
+const estimateText = computed(() => {
+  if (daysRemaining.value === null) {
+    return "Not enough history yet to estimate";
+  }
+  if (daysRemaining.value <= 0) {
+    return "Already at or below the 20% target";
+  }
+  return `~${daysRemaining.value.toFixed(1)} days until 20%`;
+});
+
+// --- Chart geometry (plain SVG, no charting library) ---
+const CHART_WIDTH = 800;
+const CHART_HEIGHT = 320;
+const PAD = { top: 20, right: 24, bottom: 36, left: 44 };
+const plotWidth = CHART_WIDTH - PAD.left - PAD.right;
+const plotHeight = CHART_HEIGHT - PAD.top - PAD.bottom;
+
+const timeRange = computed(() => {
+  if (entries.value.length === 0) return [0, 1];
+  const times = entries.value.map((e) => e.t);
+  const min = Math.min(...times);
+  const max = Math.max(...times);
+  return [min, max === min ? min + 1 : max];
+});
+
+function xForTime(t) {
+  const [min, max] = timeRange.value;
+  return PAD.left + ((t - min) / (max - min)) * plotWidth;
+}
+
+function yForPercent(p) {
+  return PAD.top + plotHeight - (Math.max(0, Math.min(100, p)) / 100) * plotHeight;
+}
+
+const linePoints = computed(() =>
+  entries.value.map((e) => `${xForTime(e.t).toFixed(1)},${yForPercent(e.p).toFixed(1)}`).join(" ")
+);
+
+const targetLineY = computed(() => yForPercent(20));
+
+const yTicks = [0, 20, 40, 60, 80, 100];
+
+// A handful of evenly-spaced date labels along the x-axis (avoids clutter
+// with potentially hundreds of points over a long history).
+const xTicks = computed(() => {
+  if (entries.value.length === 0) return [];
+  const [min, max] = timeRange.value;
+  const count = 5;
+  const ticks = [];
+  for (let i = 0; i < count; i++) {
+    const t = min + ((max - min) * i) / (count - 1);
+    ticks.push({
+      x: xForTime(t),
+      label: new Date(t * 1000).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+    });
+  }
+  return ticks;
+});
+
+function pointTitle(e) {
+  const date = new Date(e.t * 1000).toLocaleString();
+  return `${date}\n${e.p}%${e.c ? " (charging)" : ""}`;
+}
+</script>
+
+<template>
+  <v-card>
+    <v-card-title class="d-flex align-center">
+      <v-icon icon="mdi-battery-clock-outline" class="mr-2" />
+      Battery History
+    </v-card-title>
+
+    <v-card-text>
+      <div v-if="loading" class="d-flex justify-center align-center py-12">
+        <v-progress-circular indeterminate color="primary" />
+      </div>
+
+      <v-alert v-else-if="entries.length === 0" type="info" variant="tonal">
+        No battery history recorded yet. A reading is saved once per displayed image (requires a
+        battery to be present and persistent storage to be mounted).
+      </v-alert>
+
+      <template v-else>
+        <div class="d-flex align-center flex-wrap ga-4 mb-4">
+          <v-chip color="primary" variant="tonal" size="large">
+            <v-icon icon="mdi-battery-arrow-down-outline" start />
+            {{ estimateText }}
+          </v-chip>
+          <span class="text-caption text-medium-emphasis">
+            {{ entries.length }} reading{{ entries.length === 1 ? "" : "s" }} since the last full
+            charge or reset
+          </span>
+        </div>
+
+        <svg
+          :viewBox="`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`"
+          preserveAspectRatio="xMidYMid meet"
+          style="width: 100%; height: auto; max-height: 360px"
+        >
+          <!-- Y gridlines + labels -->
+          <g v-for="tick in yTicks" :key="'y' + tick">
+            <line
+              :x1="PAD.left"
+              :x2="CHART_WIDTH - PAD.right"
+              :y1="yForPercent(tick)"
+              :y2="yForPercent(tick)"
+              stroke="currentColor"
+              stroke-opacity="0.12"
+            />
+            <text
+              :x="PAD.left - 8"
+              :y="yForPercent(tick) + 4"
+              text-anchor="end"
+              font-size="11"
+              fill="currentColor"
+              fill-opacity="0.6"
+            >
+              {{ tick }}%
+            </text>
+          </g>
+
+          <!-- 20% target reference line -->
+          <line
+            :x1="PAD.left"
+            :x2="CHART_WIDTH - PAD.right"
+            :y1="targetLineY"
+            :y2="targetLineY"
+            stroke="#e53935"
+            stroke-width="1.5"
+            stroke-dasharray="6,4"
+            stroke-opacity="0.7"
+          />
+
+          <!-- X labels -->
+          <text
+            v-for="tick in xTicks"
+            :key="tick.label + tick.x"
+            :x="tick.x"
+            :y="CHART_HEIGHT - PAD.bottom + 20"
+            text-anchor="middle"
+            font-size="11"
+            fill="currentColor"
+            fill-opacity="0.6"
+          >
+            {{ tick.label }}
+          </text>
+
+          <!-- The battery-level line -->
+          <polyline :points="linePoints" fill="none" stroke="#1976d2" stroke-width="2" />
+
+          <!-- Points, colored by charging state -->
+          <circle
+            v-for="(e, i) in entries"
+            :key="i"
+            :cx="xForTime(e.t)"
+            :cy="yForPercent(e.p)"
+            :r="e.c ? 3.5 : 2.5"
+            :fill="e.c ? '#fb8c00' : '#1976d2'"
+          >
+            <title>{{ pointTitle(e) }}</title>
+          </circle>
+        </svg>
+
+        <div class="d-flex align-center ga-4 mt-2">
+          <div class="d-flex align-center ga-1">
+            <span class="legend-dot" style="background: #1976d2"></span>
+            <span class="text-caption text-medium-emphasis">On battery</span>
+          </div>
+          <div class="d-flex align-center ga-1">
+            <span class="legend-dot" style="background: #fb8c00"></span>
+            <span class="text-caption text-medium-emphasis">Charging / USB connected</span>
+          </div>
+          <div class="d-flex align-center ga-1">
+            <span class="legend-line"></span>
+            <span class="text-caption text-medium-emphasis">20% target</span>
+          </div>
+        </div>
+
+        <div class="text-caption text-medium-emphasis mt-4">
+          One reading is recorded after each image change. The history (and the estimate above)
+          resets automatically once the battery reaches 95% or after 180 days, whichever comes
+          first.
+        </div>
+      </template>
+    </v-card-text>
+  </v-card>
+</template>
+
+<style scoped>
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.legend-line {
+  width: 16px;
+  height: 0;
+  border-top: 1.5px dashed #e53935;
+  display: inline-block;
+}
+</style>

--- a/webapp/src/components/SettingsPanel.vue
+++ b/webapp/src/components/SettingsPanel.vue
@@ -844,6 +844,20 @@ async function performFactoryReset() {
                       "/wake_notify" bot command.
                     </div>
 
+                    <v-switch
+                      v-model="settingsStore.deviceSettings.telegramRotationNotifyEnabled"
+                      label="Notify when a wake shows a non-Telegram image"
+                      color="primary"
+                      class="mb-2"
+                      hide-details
+                    />
+                    <div class="text-caption text-medium-emphasis mb-4">
+                      When a wake falls back to normal album rotation (no new Telegram image that
+                      cycle), sends a thumbnail of whatever got displayed instead, so the chat
+                      still shows what's currently on the frame. Also togglable via the
+                      "/rotation_notify" bot command.
+                    </div>
+
                     <v-alert
                       v-if="settingsStore.deviceSettings.lastFetchError"
                       type="error"

--- a/webapp/src/components/SettingsPanel.vue
+++ b/webapp/src/components/SettingsPanel.vue
@@ -859,6 +859,20 @@ async function performFactoryReset() {
                       "/rotation_notify" bot command.
                     </div>
 
+                    <v-switch
+                      v-model="settingsStore.deviceSettings.telegramKeepOriginalsEnabled"
+                      label="Keep original photos as received"
+                      color="primary"
+                      class="mb-2"
+                      hide-details
+                    />
+                    <div class="text-caption text-medium-emphasis mb-4">
+                      Saves a copy of each Telegram photo exactly as received, before e-paper
+                      processing (dithering/palette quantization), under Telegram/Originals on the
+                      SD card. Not shown in the gallery or rotation. Also togglable via the
+                      "/keep_originals" bot command.
+                    </div>
+
                     <v-alert
                       v-if="settingsStore.deviceSettings.lastFetchError"
                       type="error"

--- a/webapp/src/components/SettingsPanel.vue
+++ b/webapp/src/components/SettingsPanel.vue
@@ -134,7 +134,10 @@ const rotationOptions = [
 ];
 
 const rotationModeOptions = computed(() => {
-  const options = [{ title: "URL - Fetch image from URL", value: "url" }];
+  const options = [
+    { title: "URL - Fetch image from URL", value: "url" },
+    { title: "Telegram - Receive images via Telegram bot", value: "telegram" },
+  ];
   if (appStore.systemInfo.sdcard_inserted || appStore.systemInfo.has_flash_storage) {
     options.unshift({ title: "Storage - Rotate through images", value: "storage" });
   }
@@ -714,6 +717,98 @@ async function performFactoryReset() {
                   </v-card-text>
                 </v-card>
               </v-expand-transition>
+
+              <v-expand-transition>
+                <v-card
+                  v-if="
+                    settingsStore.deviceSettings.autoRotate &&
+                    settingsStore.deviceSettings.rotationMode === 'telegram'
+                  "
+                  variant="tonal"
+                  class="mb-4"
+                >
+                  <v-card-text>
+                    <v-chip
+                      :color="settingsStore.deviceSettings.telegramConfigured ? 'success' : 'warning'"
+                      size="small"
+                      variant="tonal"
+                      class="mb-4"
+                    >
+                      <v-icon start>{{
+                        settingsStore.deviceSettings.telegramConfigured
+                          ? "mdi-check-circle"
+                          : "mdi-alert-circle-outline"
+                      }}</v-icon>
+                      {{
+                        settingsStore.deviceSettings.telegramConfigured
+                          ? "Telegram bot configured"
+                          : "Bot token and chat ID required"
+                      }}
+                    </v-chip>
+
+                    <v-text-field
+                      v-model="settingsStore.deviceSettings.telegramBotToken"
+                      label="Telegram Bot Token"
+                      variant="outlined"
+                      hint="From @BotFather, e.g. 123456789:AAbecomes..."
+                      persistent-hint
+                      class="mb-4"
+                    />
+
+                    <v-text-field
+                      v-model="settingsStore.deviceSettings.telegramChatId"
+                      label="Telegram Chat ID"
+                      variant="outlined"
+                      hint="Only messages from this numeric chat/group ID are processed"
+                      persistent-hint
+                      class="mb-4"
+                    />
+
+                    <v-switch
+                      v-model="settingsStore.deviceSettings.telegramPairingEnabled"
+                      label="Combine mismatched-orientation photos instead of showing one alone"
+                      color="primary"
+                      class="mb-2"
+                      hide-details
+                    />
+                    <div class="text-caption text-medium-emphasis mb-4">
+                      Two portrait photos on a landscape frame (or two landscape photos on a
+                      portrait frame) are combined side by side / stacked. A lone mismatched
+                      photo is held back until its partner arrives. Also togglable via the
+                      "/pairing" bot command.
+                    </div>
+
+                    <v-switch
+                      v-model="settingsStore.deviceSettings.telegramWakeNotifyEnabled"
+                      label="Send a status ping on every wake"
+                      color="primary"
+                      class="mb-2"
+                      hide-details
+                    />
+                    <div class="text-caption text-medium-emphasis mb-4">
+                      Sends SSID, IP, battery, reset/wake reason and rotation schedule to the bot
+                      on every poll, even when there are no new messages. Also togglable via the
+                      "/wake_notify" bot command.
+                    </div>
+
+                    <v-alert
+                      v-if="settingsStore.deviceSettings.lastFetchError"
+                      type="error"
+                      variant="tonal"
+                      density="compact"
+                      class="mb-2"
+                    >
+                      Last fetch error: {{ settingsStore.deviceSettings.lastFetchError }}
+                    </v-alert>
+
+                    <div class="text-caption text-medium-emphasis">
+                      Send a photo or image file to the bot, or a "/" command
+                      (/status, /restart, /clear). Send /telegram_reset to
+                      immediately clear a stuck message queue.
+                    </div>
+                  </v-card-text>
+                </v-card>
+              </v-expand-transition>
             </div>
           </v-tabs-window-item>
 
@@ -737,10 +832,59 @@ async function performFactoryReset() {
                 power consumption. Only disable if permanently powered via USB.
               </v-alert>
             </v-expand-transition>
+
+            <v-switch
+              v-model="settingsStore.deviceSettings.otaCheckEnabled"
+              label="Enable automatic update checks"
+              color="primary"
+              class="mb-2 mt-4"
+              hide-details
+            />
+            <div class="text-caption text-medium-emphasis mb-4">
+              Checks for a new firmware release once a day and on every cold boot. A manually
+              triggered "Check for updates" (below) always works regardless of this setting.
+              Useful to turn off for self-built/dev firmware, which otherwise always reports an
+              "update available".
+            </div>
+
+            <v-switch
+              v-model="settingsStore.deviceSettings.wifiPerformanceModeEnabled"
+              label="Enable WiFi performance mode"
+              color="primary"
+              class="mb-2"
+              hide-details
+            />
+            <div class="text-caption text-medium-emphasis mb-4">
+              When on (default), the frame automatically switches to full WiFi receive power
+              (~60-70 mA extra draw, but a much snappier web UI) whenever someone might be
+              looking - an interactive wake or USB power - and drops back to WiFi power-save
+              otherwise. Turn off to always stay in power-save, even during interactive use,
+              trading web UI responsiveness for lower battery draw.
+            </div>
+
+            <v-switch
+              v-model="settingsStore.deviceSettings.errorOverlayEnabled"
+              label="Show error overlay on display for persistent failures"
+              color="primary"
+              hide-details
+            />
+            <div class="text-caption text-medium-emphasis">
+              After 3 consecutive failed WiFi connection attempts on a scheduled wake, overlays a
+              short error message on the currently displayed image (without modifying the saved
+              file) so the problem is visible on the frame itself, not just in logs. Also
+              togglable via the "/error_overlay" Telegram bot command.
+            </div>
           </v-tabs-window-item>
 
           <!-- Home Assistant Tab -->
           <v-tabs-window-item class="mt-2" value="homeAssistant">
+            <v-switch
+              v-model="settingsStore.deviceSettings.haEnabled"
+              label="Enable Home Assistant integration"
+              color="primary"
+              class="mb-4"
+              hide-details
+            />
             <v-text-field
               v-model="settingsStore.deviceSettings.haUrl"
               label="Home Assistant URL"
@@ -748,6 +892,7 @@ async function performFactoryReset() {
               placeholder="http://homeassistant.local:8123"
               hint="Configure for dynamic image serving and battery level reporting"
               persistent-hint
+              :disabled="!settingsStore.deviceSettings.haEnabled"
             />
           </v-tabs-window-item>
 

--- a/webapp/src/components/SettingsPanel.vue
+++ b/webapp/src/components/SettingsPanel.vue
@@ -11,6 +11,33 @@ import { wideEdit } from "../utils/uiPrefs";
 const settingsStore = useSettingsStore();
 const appStore = useAppStore();
 
+const snackbar = ref(false);
+const snackbarText = ref("");
+const snackbarColor = ref("success");
+function showSnackbar(text, color) {
+  snackbarText.value = text;
+  snackbarColor.value = color;
+  snackbar.value = true;
+}
+
+const testingErrorOverlay = ref(false);
+async function testErrorOverlay() {
+  testingErrorOverlay.value = true;
+  try {
+    const response = await fetch("/api/error-overlay/test", { method: "POST" });
+    const data = await response.json().catch(() => ({}));
+    if (response.ok) {
+      showSnackbar(data.message || "Error overlay displayed", "success");
+    } else {
+      showSnackbar(data.message || "Failed to display error overlay", "error");
+    }
+  } catch (_error) {
+    showSnackbar("Failed to display error overlay", "error");
+  } finally {
+    testingErrorOverlay.value = false;
+  }
+}
+
 // The device rejects the entire config request when any schedule rule is
 // invalid, empty or over the 7-rule budget — gate saving on the same checks.
 const scheduleValid = computed(() => {
@@ -625,7 +652,33 @@ async function performFactoryReset() {
                       label="Storage Rotation Logic"
                       variant="outlined"
                       hide-details
+                      class="mb-4"
                     />
+
+                    <v-switch
+                      v-model="settingsStore.deviceSettings.rotationPairingEnabled"
+                      label="Combine mismatched-orientation images"
+                      color="primary"
+                      hide-details
+                    />
+                    <div class="text-caption text-medium-emphasis">
+                      When the next image to show doesn't match the panel's orientation, looks for
+                      another mismatched image in the active album(s) and combines them side by
+                      side instead of showing one letterboxed. The combined image is saved
+                      permanently in the album (the two originals are kept too). Also togglable
+                      via the "/rotation_pairing" Telegram bot command.
+                    </div>
+                    <v-alert
+                      v-if="settingsStore.deviceSettings.rotationPairingEnabled &&
+                        settingsStore.deviceSettings.sdRotationMode === 'sequential'"
+                      type="warning"
+                      variant="tonal"
+                      density="compact"
+                      class="mt-2"
+                    >
+                      Only takes effect in Random rotation logic - Sequential mode ignores this
+                      setting.
+                    </v-alert>
                   </v-card-text>
                 </v-card>
               </v-expand-transition>
@@ -868,11 +921,25 @@ async function performFactoryReset() {
               color="primary"
               hide-details
             />
-            <div class="text-caption text-medium-emphasis">
+            <div class="text-caption text-medium-emphasis mb-2">
               After 3 consecutive failed WiFi connection attempts on a scheduled wake, overlays a
               short error message on the currently displayed image (without modifying the saved
               file) so the problem is visible on the frame itself, not just in logs. Also
               togglable via the "/error_overlay" Telegram bot command.
+            </div>
+            <v-btn
+              variant="outlined"
+              size="small"
+              :loading="testingErrorOverlay"
+              @click="testErrorOverlay"
+            >
+              <v-icon icon="mdi-alert-outline" start />
+              Test Error Overlay
+            </v-btn>
+            <div class="text-caption text-medium-emphasis mt-1">
+              Displays an example error message right now, regardless of the setting above -
+              useful to preview what it looks like. Overlays onto the current image if there is
+              one, otherwise shows it on a blank screen.
             </div>
           </v-tabs-window-item>
 
@@ -1146,6 +1213,10 @@ async function performFactoryReset() {
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <v-snackbar v-model="snackbar" :color="snackbarColor" timeout="3000">
+      {{ snackbarText }}
+    </v-snackbar>
   </div>
 </template>
 

--- a/webapp/src/stores/app.js
+++ b/webapp/src/stores/app.js
@@ -100,7 +100,13 @@ export const useAppStore = defineStore("app", () => {
         images.value = [];
         return;
       }
-      const response = await fetch(`${API_BASE}/api/images?album=${encodeURIComponent(albumName)}`);
+      // Mirrors AlbumGallery.vue's "Show thumbnails" preference (same
+      // localStorage key) so the device can skip its per-file thumbnail
+      // existence check entirely when the client won't render any anyway.
+      const showThumbnails = localStorage.getItem("photoframe_show_thumbnails") === "true";
+      const response = await fetch(
+        `${API_BASE}/api/images?album=${encodeURIComponent(albumName)}&thumbnails=${showThumbnails ? 1 : 0}`
+      );
       if (!response.ok || response.headers.get("content-type")?.includes("text/html")) {
         images.value = [];
         return;

--- a/webapp/src/stores/settings.js
+++ b/webapp/src/stores/settings.js
@@ -46,12 +46,22 @@ export const useSettingsStore = defineStore("settings", () => {
     httpHeaderKey: "",
     httpHeaderValue: "",
     saveDownloadedImages: true,
+    // Auto Rotate - Telegram
+    telegramBotToken: "",
+    telegramChatId: "",
+    telegramConfigured: false,
+    telegramPairingEnabled: true,
+    telegramWakeNotifyEnabled: false,
     // Home Assistant
     haUrl: "",
+    haEnabled: false,
     // Power
     deepSleepEnabled: true,
+    otaCheckEnabled: true,
+    wifiPerformanceModeEnabled: true,
     // Debugging
     debugLogEnabled: false,
+    errorOverlayEnabled: false,
     // AI API Keys (for client-side AI generation)
     aiCredentials: {
       openaiApiKey: "",
@@ -191,8 +201,12 @@ export const useSettingsStore = defineStore("settings", () => {
       deviceSettings.value.caCertSet = data.ca_cert_set || false;
       deviceSettings.value.lastFetchError = data.last_fetch_error || "";
       deviceSettings.value.deepSleepEnabled = data.deep_sleep_enabled !== false;
+      deviceSettings.value.otaCheckEnabled = data.ota_check_enabled !== false;
+      deviceSettings.value.wifiPerformanceModeEnabled = data.wifi_performance_mode_enabled !== false;
       deviceSettings.value.debugLogEnabled = data.debug_log_enabled === true;
+      deviceSettings.value.errorOverlayEnabled = data.error_overlay_enabled === true;
       deviceSettings.value.haUrl = data.ha_url || "";
+      deviceSettings.value.haEnabled = data.ha_enabled === true;
       deviceSettings.value.saveDownloadedImages = data.save_downloaded_images !== false;
       deviceSettings.value.accessToken = data.access_token || "";
       deviceSettings.value.httpHeaderKey = data.http_header_key || "";
@@ -201,6 +215,11 @@ export const useSettingsStore = defineStore("settings", () => {
       appliedOrientation.value = deviceSettings.value.displayOrientation;
       deviceSettings.value.rotationMode = data.rotation_mode || "storage";
       deviceSettings.value.sdRotationMode = data.sd_rotation_mode || "random";
+      deviceSettings.value.telegramBotToken = data.telegram_bot_token || "";
+      deviceSettings.value.telegramChatId = data.telegram_chat_id || "";
+      deviceSettings.value.telegramConfigured = data.telegram_configured === true;
+      deviceSettings.value.telegramWakeNotifyEnabled = data.telegram_wake_notify_enabled === true;
+      deviceSettings.value.telegramPairingEnabled = data.telegram_pairing_enabled !== false;
       deviceSettings.value.deviceName = data.device_name || "PhotoFrame";
       deviceSettings.value.ntpServer = data.ntp_server || "pool.ntp.org";
       deviceSettings.value.ipMode = data.ip_mode || "dhcp";
@@ -256,9 +275,17 @@ export const useSettingsStore = defineStore("settings", () => {
       rotation_mode: deviceSettings.value.rotationMode,
       sd_rotation_mode: deviceSettings.value.sdRotationMode,
       image_url: deviceSettings.value.imageUrl,
+      telegram_bot_token: deviceSettings.value.telegramBotToken,
+      telegram_chat_id: deviceSettings.value.telegramChatId,
+      telegram_pairing_enabled: deviceSettings.value.telegramPairingEnabled,
+      telegram_wake_notify_enabled: deviceSettings.value.telegramWakeNotifyEnabled,
       ha_url: deviceSettings.value.haUrl,
+      ha_enabled: deviceSettings.value.haEnabled,
       deep_sleep_enabled: deviceSettings.value.deepSleepEnabled,
+      ota_check_enabled: deviceSettings.value.otaCheckEnabled,
+      wifi_performance_mode_enabled: deviceSettings.value.wifiPerformanceModeEnabled,
       debug_log_enabled: deviceSettings.value.debugLogEnabled,
+      error_overlay_enabled: deviceSettings.value.errorOverlayEnabled,
       save_downloaded_images: deviceSettings.value.saveDownloadedImages,
       display_orientation: deviceSettings.value.displayOrientation,
       device_name: deviceSettings.value.deviceName,

--- a/webapp/src/stores/settings.js
+++ b/webapp/src/stores/settings.js
@@ -61,6 +61,7 @@ export const useSettingsStore = defineStore("settings", () => {
     wifiPerformanceModeEnabled: true,
     rotationPairingEnabled: false,
     telegramRotationNotifyEnabled: false,
+    telegramKeepOriginalsEnabled: false,
     // Debugging
     debugLogEnabled: false,
     errorOverlayEnabled: false,
@@ -208,6 +209,8 @@ export const useSettingsStore = defineStore("settings", () => {
       deviceSettings.value.rotationPairingEnabled = data.rotation_pairing_enabled === true;
       deviceSettings.value.telegramRotationNotifyEnabled =
         data.telegram_rotation_notify_enabled === true;
+      deviceSettings.value.telegramKeepOriginalsEnabled =
+        data.telegram_keep_originals_enabled === true;
       deviceSettings.value.debugLogEnabled = data.debug_log_enabled === true;
       deviceSettings.value.errorOverlayEnabled = data.error_overlay_enabled === true;
       deviceSettings.value.haUrl = data.ha_url || "";
@@ -291,6 +294,7 @@ export const useSettingsStore = defineStore("settings", () => {
       wifi_performance_mode_enabled: deviceSettings.value.wifiPerformanceModeEnabled,
       rotation_pairing_enabled: deviceSettings.value.rotationPairingEnabled,
       telegram_rotation_notify_enabled: deviceSettings.value.telegramRotationNotifyEnabled,
+      telegram_keep_originals_enabled: deviceSettings.value.telegramKeepOriginalsEnabled,
       debug_log_enabled: deviceSettings.value.debugLogEnabled,
       error_overlay_enabled: deviceSettings.value.errorOverlayEnabled,
       save_downloaded_images: deviceSettings.value.saveDownloadedImages,

--- a/webapp/src/stores/settings.js
+++ b/webapp/src/stores/settings.js
@@ -60,6 +60,7 @@ export const useSettingsStore = defineStore("settings", () => {
     otaCheckEnabled: true,
     wifiPerformanceModeEnabled: true,
     rotationPairingEnabled: false,
+    telegramRotationNotifyEnabled: false,
     // Debugging
     debugLogEnabled: false,
     errorOverlayEnabled: false,
@@ -205,6 +206,8 @@ export const useSettingsStore = defineStore("settings", () => {
       deviceSettings.value.otaCheckEnabled = data.ota_check_enabled !== false;
       deviceSettings.value.wifiPerformanceModeEnabled = data.wifi_performance_mode_enabled !== false;
       deviceSettings.value.rotationPairingEnabled = data.rotation_pairing_enabled === true;
+      deviceSettings.value.telegramRotationNotifyEnabled =
+        data.telegram_rotation_notify_enabled === true;
       deviceSettings.value.debugLogEnabled = data.debug_log_enabled === true;
       deviceSettings.value.errorOverlayEnabled = data.error_overlay_enabled === true;
       deviceSettings.value.haUrl = data.ha_url || "";
@@ -287,6 +290,7 @@ export const useSettingsStore = defineStore("settings", () => {
       ota_check_enabled: deviceSettings.value.otaCheckEnabled,
       wifi_performance_mode_enabled: deviceSettings.value.wifiPerformanceModeEnabled,
       rotation_pairing_enabled: deviceSettings.value.rotationPairingEnabled,
+      telegram_rotation_notify_enabled: deviceSettings.value.telegramRotationNotifyEnabled,
       debug_log_enabled: deviceSettings.value.debugLogEnabled,
       error_overlay_enabled: deviceSettings.value.errorOverlayEnabled,
       save_downloaded_images: deviceSettings.value.saveDownloadedImages,

--- a/webapp/src/stores/settings.js
+++ b/webapp/src/stores/settings.js
@@ -59,6 +59,7 @@ export const useSettingsStore = defineStore("settings", () => {
     deepSleepEnabled: true,
     otaCheckEnabled: true,
     wifiPerformanceModeEnabled: true,
+    rotationPairingEnabled: false,
     // Debugging
     debugLogEnabled: false,
     errorOverlayEnabled: false,
@@ -203,6 +204,7 @@ export const useSettingsStore = defineStore("settings", () => {
       deviceSettings.value.deepSleepEnabled = data.deep_sleep_enabled !== false;
       deviceSettings.value.otaCheckEnabled = data.ota_check_enabled !== false;
       deviceSettings.value.wifiPerformanceModeEnabled = data.wifi_performance_mode_enabled !== false;
+      deviceSettings.value.rotationPairingEnabled = data.rotation_pairing_enabled === true;
       deviceSettings.value.debugLogEnabled = data.debug_log_enabled === true;
       deviceSettings.value.errorOverlayEnabled = data.error_overlay_enabled === true;
       deviceSettings.value.haUrl = data.ha_url || "";
@@ -284,6 +286,7 @@ export const useSettingsStore = defineStore("settings", () => {
       deep_sleep_enabled: deviceSettings.value.deepSleepEnabled,
       ota_check_enabled: deviceSettings.value.otaCheckEnabled,
       wifi_performance_mode_enabled: deviceSettings.value.wifiPerformanceModeEnabled,
+      rotation_pairing_enabled: deviceSettings.value.rotationPairingEnabled,
       debug_log_enabled: deviceSettings.value.debugLogEnabled,
       error_overlay_enabled: deviceSettings.value.errorOverlayEnabled,
       save_downloaded_images: deviceSettings.value.saveDownloadedImages,

--- a/webapp/src/views/MainApp.vue
+++ b/webapp/src/views/MainApp.vue
@@ -6,9 +6,12 @@ import AlbumGallery from "../components/AlbumGallery.vue";
 import ImageUpload from "../components/ImageUpload.vue";
 import SettingsPanel from "../components/SettingsPanel.vue";
 import OtaUpdate from "../components/OtaUpdate.vue";
+import BatteryHistory from "../components/BatteryHistory.vue";
 
 const appStore = useAppStore();
 const settingsStore = useSettingsStore();
+
+const mainTab = ref("gallery");
 
 onMounted(async () => {
   // Load system info first to check for SD card
@@ -124,15 +127,34 @@ onUnmounted(() => {
           text="This device supports an SD card. To upload images and create multiple albums, please insert one and restart the device."
         ></v-alert>
 
-        <AlbumGallery
-          v-if="appStore.systemInfo.sdcard_inserted || appStore.systemInfo.has_flash_storage"
-        />
+        <v-tabs v-model="mainTab" color="primary" show-arrows class="mb-6">
+          <v-tab value="gallery">Gallery</v-tab>
+          <v-tab value="settings">Settings</v-tab>
+          <v-tab value="battery">Battery History</v-tab>
+          <v-tab value="updates">Updates</v-tab>
+        </v-tabs>
 
-        <ImageUpload class="mt-6" />
+        <v-tabs-window v-model="mainTab">
+          <v-tabs-window-item value="gallery">
+            <AlbumGallery
+              v-if="appStore.systemInfo.sdcard_inserted || appStore.systemInfo.has_flash_storage"
+            />
 
-        <SettingsPanel class="mt-6" />
+            <ImageUpload class="mt-6" />
+          </v-tabs-window-item>
 
-        <OtaUpdate class="mt-6" />
+          <v-tabs-window-item value="settings">
+            <SettingsPanel />
+          </v-tabs-window-item>
+
+          <v-tabs-window-item value="battery">
+            <BatteryHistory />
+          </v-tabs-window-item>
+
+          <v-tabs-window-item value="updates">
+            <OtaUpdate />
+          </v-tabs-window-item>
+        </v-tabs-window>
       </v-container>
     </v-main>
 


### PR DESCRIPTION
## Summary

Adds a native Telegram Bot rotation mode, alongside (not replacing) the existing SD-card and
URL-fetch rotation modes. The frame long-polls the Telegram Bot API directly - no additional
server required - and accepts photos or files, with automatic fallback through Telegram's other
resolutions when a photo only comes back as progressive JPEG (which the firmware's decoder can't
read).

Full details in [docs/TELEGRAM.md](https://github.com/t3ste/Tlg-esp32-photoframe/blob/telegram-bot-integration/docs/TELEGRAM.md).

- **Commit 1** (`feat`): the integration itself - polling, download/fallback, captions, emergency
  `/telegram_reset`, orientation pairing, the full command set, and several new opt-in toggles
  (all defaulting to preserve existing behavior).
- **Commit 2** (`fix`): two coredump-confirmed stability issues found testing on battery power on
  the Waveshare PhotoPainter (esp_pm/WiFi interrupt race, main-task stack overflow) - both in
  shared power-management code, not gated behind the new feature.
- **Commit 3** (`docs`): `docs/TELEGRAM.md` plus a README feature-list entry.

## Test plan

- [x] `idf.py build` succeeds for `waveshare_photopainter_73`
- [x] Verified byte-for-byte against the working branch this was extracted from (no content lost
      in the commit split)
- [ ] Maintainer review of the command surface / config additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)